### PR TITLE
Add missing JPA & Liquibase config

### DIFF
--- a/services/src/main/resources/subscriptionoperation-defaults.yml
+++ b/services/src/main/resources/subscriptionoperation-defaults.yml
@@ -31,3 +31,9 @@ broadleaf:
     subscriptionprovider:
       url: https://localhost:8467/billing
       subscription-uri: /subscriptions
+    database:
+      provider: jpa
+    liquibase:
+      change-log: ${changelogPath}
+      liquibase-schema: ${liquibase-schema}
+      default-schema: ${default-schema}


### PR DESCRIPTION
Note: JPA used in this orchestration service only for message idempotency concerns.

https://github.com/BroadleafCommerce/MicroPM/issues/5085