### PR TITLE
Updates to Subscription Ops APIs

### DIFF
--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpoint.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpoint.java
@@ -21,6 +21,7 @@ import org.broadleafcommerce.frameworkmapping.annotation.FrameworkMapping;
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkRestController;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.PathVariable;
 
@@ -45,18 +46,18 @@ import lombok.RequiredArgsConstructor;
 @FrameworkMapping(AccountSubscriptionOperationEndpoint.BASE_URI)
 public class AccountSubscriptionOperationEndpoint {
 
-    public static final String BASE_URI = "/account";
+    public static final String BASE_URI = "/accounts/{accountId}/subscriptions";
 
     @Getter(AccessLevel.PROTECTED)
     protected final SubscriptionOperationService<Subscription, SubscriptionItem, SubscriptionWithItems> subscriptionOperationService;
 
-    @FrameworkGetMapping(value = "/{accountId}/subscriptions")
+    @FrameworkGetMapping
     @Policy(permissionRoots = "ACCOUNT_SUBSCRIPTION",
             identityTypes = {IdentityType.ADMIN, IdentityType.OWNER},
             ownerIdentifierParam = 0, ownerIdentifier = "acct_id,parent_accts")
     public Page<SubscriptionWithItems> readAccountSubscriptions(
             @PathVariable("accountId") String accountId,
-            @PageableDefault Pageable page,
+            @PageableDefault(sort = "createdDate", direction = Sort.Direction.DESC) Pageable page,
             Node filters,
             @ContextOperation(OperationType.READ) final ContextInfo contextInfo) {
         return subscriptionOperationService.readSubscriptionsForUserTypeAndUserId(

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpoint.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpoint.java
@@ -23,6 +23,7 @@ import org.broadleafcommerce.frameworkmapping.annotation.FrameworkPutMapping;
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkRestController;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -50,18 +51,18 @@ import lombok.RequiredArgsConstructor;
 @FrameworkMapping(CustomerSubscriptionOperationEndpoint.BASE_URI)
 public class CustomerSubscriptionOperationEndpoint {
 
-    public static final String BASE_URI = "/customer/{customerId}/subscriptions";
+    public static final String BASE_URI = "/customers/{customerId}/subscriptions";
 
     @Getter(AccessLevel.PROTECTED)
     protected final SubscriptionOperationService<Subscription, SubscriptionItem, SubscriptionWithItems> subscriptionOperationService;
 
-    @FrameworkGetMapping()
+    @FrameworkGetMapping
     @Policy(permissionRoots = "CUSTOMER_SUBSCRIPTION",
             identityTypes = {IdentityType.OWNER},
             ownerIdentifierParam = 0)
     public Page<SubscriptionWithItems> readCustomerSubscriptions(
             @PathVariable("customerId") String customerId,
-            @PageableDefault Pageable page,
+            @PageableDefault(sort = "createdDate", direction = Sort.Direction.DESC) Pageable page,
             Node filters,
             @ContextOperation(OperationType.READ) final ContextInfo contextInfo) {
         return subscriptionOperationService.readSubscriptionsForUserTypeAndUserId(

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpoint.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpoint.java
@@ -19,12 +19,12 @@ package com.broadleafcommerce.subscriptionoperation.web.endpoint;
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkGetMapping;
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkMapping;
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkPostMapping;
-import org.broadleafcommerce.frameworkmapping.annotation.FrameworkPutMapping;
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkRestController;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -69,7 +69,8 @@ public class CustomerSubscriptionOperationEndpoint {
                 DefaultUserRefTypes.BLC_CUSTOMER.name(), customerId, page, filters, contextInfo);
     }
 
-    @FrameworkPostMapping(value = "/{subscriptionId}/upgrade")
+    @FrameworkPostMapping(value = "/{subscriptionId}/upgrade",
+            consumes = MediaType.APPLICATION_JSON_VALUE)
     @Policy(permissionRoots = {"CUSTOMER_SUBSCRIPTION"},
             identityTypes = {IdentityType.OWNER},
             ownerIdentifierParam = 0,
@@ -83,7 +84,8 @@ public class CustomerSubscriptionOperationEndpoint {
         return subscriptionOperationService.upgradeSubscription(upgradeRequest, contextInfo);
     }
 
-    @FrameworkPutMapping(value = "/{subscriptionId}/cancel")
+    @FrameworkPostMapping(value = "/{subscriptionId}/cancel",
+            consumes = MediaType.APPLICATION_JSON_VALUE)
     @Policy(permissionRoots = {"CUSTOMER_SUBSCRIPTION"},
             identityTypes = {IdentityType.OWNER},
             ownerIdentifierParam = 0,

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/SubscriptionOperationEndpoint.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/SubscriptionOperationEndpoint.java
@@ -24,6 +24,7 @@ import org.broadleafcommerce.frameworkmapping.annotation.FrameworkPutMapping;
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkRestController;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -59,7 +60,7 @@ public class SubscriptionOperationEndpoint {
     public Page<SubscriptionWithItems> readUserSubscriptions(
             @RequestParam("userType") String userType,
             @RequestParam("userId") String userId,
-            @PageableDefault Pageable page,
+            @PageableDefault(sort = "createdDate", direction = Sort.Direction.DESC) Pageable page,
             Node filters,
             @ContextOperation(OperationType.READ) final ContextInfo contextInfo) {
         return subscriptionOperationService.readSubscriptionsForUserTypeAndUserId(userType, userId,

--- a/services/src/test/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpointIT.java
+++ b/services/src/test/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpointIT.java
@@ -60,7 +60,7 @@ import io.azam.ulidj.ULID;
 class AccountSubscriptionOperationEndpointIT {
 
     protected static final String SYSTEM_SUBSCRIPTION_URI = "/subscription-ops";
-    protected static final String ACCOUNT_URI = "/account";
+    protected static final String ACCOUNT_URI = "/accounts";
     protected static final String ACCOUNT_READ_URI = "/{accountId}/subscriptions";
 
     protected static final String CUSTOMER_SUBSCRIPTION = "CUSTOMER_SUBSCRIPTION";

--- a/services/src/test/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpointIT.java
+++ b/services/src/test/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpointIT.java
@@ -59,7 +59,7 @@ import io.azam.ulidj.ULID;
 class CustomerSubscriptionOperationEndpointIT {
 
     protected static final String SYSTEM_SUBSCRIPTION_URI = "/subscription-ops";
-    protected static final String CUSTOMER_URI = "/customer";
+    protected static final String CUSTOMER_URI = "/customers";
     protected static final String CUSTOMER_READ_URI = "/{customerId}/subscriptions";
 
     protected static final String CUSTOMER_SUBSCRIPTION = "CUSTOMER_SUBSCRIPTION";


### PR DESCRIPTION
Related to BroadleafCommerce/MicroPM#5127

- Added default sort on `createDate` for Subscriptions
- Added default sort to read all endpoints and updated pathname to fit REST semantics better
- Added missing media types