### PR TITLE
Correct how we pass pagination params & Introduce secondary source references for Subscription

### DIFF
--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/Subscription.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/Subscription.java
@@ -23,6 +23,7 @@ import com.broadleafcommerce.data.tracking.core.filtering.business.domain.Contex
 import com.broadleafcommerce.data.tracking.core.filtering.domain.Tracking;
 import com.broadleafcommerce.money.CurrencyConsumer;
 import com.broadleafcommerce.money.util.MonetaryUtils;
+import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionSourceType;
 import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultUserRefTypes;
 import com.broadleafcommerce.subscriptionoperation.domain.enums.SubscriptionStatuses;
 import com.fasterxml.jackson.annotation.JsonAlias;
@@ -131,14 +132,34 @@ public class Subscription implements ContextStateAware, CurrencySupplier, Curren
     private String alternateUserRef;
 
     /**
-     * This field shows from which process or user action this subscription originated
+     * This field shows from which process or user action this subscription originated.
+     *
+     * @see #subscriptionSourceRef
+     * @see DefaultSubscriptionSourceType
      */
     private String subscriptionSource;
 
     /**
-     * This field shows the identifier of the process or user action this subscription originated
+     * This field shows the identifier of the process or user action this subscription originated.
+     *
+     * @see #subscriptionSource
      */
     private String subscriptionSourceRef;
+
+    /**
+     * The type of the secondary source to reference, e.g, an Order Item on an Order. Optional.
+     *
+     * @see #secondarySourceRef
+     * @see DefaultSubscriptionSourceType
+     */
+    private String secondarySourceType;
+
+    /**
+     * The secondary source to reference, e.g, an Order Item on an Order. Optional.
+     *
+     * @see #secondarySourceType
+     */
+    private String secondarySourceRef;
 
     /**
      * Multi-tenancy support
@@ -148,7 +169,6 @@ public class Subscription implements ContextStateAware, CurrencySupplier, Curren
     /**
      * Frequency of billing for this subscription
      *
-     * @see DefaultSubscriptionBillingFrequencyEnum
      * @deprecated in favor of {@link #periodType} & {@link #periodFrequency}
      */
     @Deprecated
@@ -198,10 +218,7 @@ public class Subscription implements ContextStateAware, CurrencySupplier, Curren
     private String lastBillingBatchId;
 
     /**
-     * The most current status of the last {@link com.broadleafcommerce.billing.domain.BillingEvent}
-     * for this subscription
-     *
-     * @see PaymentStatusEnum
+     * The most current status of the last billing event for this subscription
      */
     private String lastBillingOperationStatus;
 
@@ -228,12 +245,7 @@ public class Subscription implements ContextStateAware, CurrencySupplier, Curren
     private Integer nextPeriod;
 
     /**
-     * Whether the system has outstanding
-     * {@link com.broadleafcommerce.subscription.domain.entitlement.Entitlement entitlements} to
-     * grant on this subscription
-     * <p>
-     * Note that this field does not have any effects if Entitlements are disabled in
-     * {@link BillingJobProperties#getEntitlements()#isEnabled()}
+     * Whether the system has outstanding entitlements to grant on this subscription
      */
     private boolean needGrantEntitlements = false;
 

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/enums/DefaultSubscriptionSourceType.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/enums/DefaultSubscriptionSourceType.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Broadleaf Commerce
+ *
+ * Licensed under the Broadleaf End User License Agreement (EULA), Version 1.1 (the
+ * "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt).
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the
+ * "Custom License") between you and Broadleaf Commerce. You may not use this file except in
+ * compliance with the applicable license.
+ *
+ * NOTICE: All information contained herein is, and remains the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained herein are proprietary to Broadleaf Commerce,
+ * LLC and may be covered by U.S. and Foreign Patents, patents in process, and are protected by
+ * trade secret or copyright law. Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
+ */
+package com.broadleafcommerce.subscriptionoperation.domain.enums;
+
+import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
+
+/**
+ * Enumerates the types of subscription sources. Used in
+ * {@link Subscription#getSubscriptionSource()} and other fields.
+ */
+public enum DefaultSubscriptionSourceType {
+
+    /**
+     * Indicates that the subscription source for a subscription is a Broadleaf Order. Default
+     * out-of-box value.
+     */
+    BLC_ORDER,
+    /**
+     * Indicates that the subscription source for a subscription is a Broadleaf Order.
+     */
+    BLC_ORDER_ITEM,
+    /**
+     * Indicates that the subscription source for a subscription is a redemption code.
+     */
+    REDEMPTION_CODE;
+
+    public static boolean isBroadleafOrder(String sourceType) {
+        return BLC_ORDER.name().equals(sourceType);
+    }
+
+    public static boolean isBroadleafOrderItem(String sourceType) {
+        return BLC_ORDER_ITEM.name().equals(sourceType);
+    }
+
+    public static boolean isRedemptionCode(String sourceType) {
+        return REDEMPTION_CODE.name().equals(sourceType);
+    }
+}

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionOperationService.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionOperationService.java
@@ -168,9 +168,12 @@ public class DefaultSubscriptionOperationService<S extends Subscription, I exten
         subscription.setRootItemRef(request.getRootItemRef());
         subscription.setUserRefType(request.getUserRefType());
         subscription.setUserRef(request.getUserRef());
+        subscription.setAlternateUserRefType(request.getAlternateUserRefType());
         subscription.setAlternateUserRef(request.getAlternateUserRef());
         subscription.setSubscriptionSource(request.getSubscriptionSource());
         subscription.setSubscriptionSourceRef(request.getSubscriptionSourceRef());
+        subscription.setSecondarySourceType(request.getSecondarySourceType());
+        subscription.setSecondarySourceRef(request.getSecondarySourceRef());
         subscription.setBillingFrequency(
                 StringUtils.defaultIfBlank(request.getBillingFrequency(), "USE_PERIOD_TYPE"));
         subscription.setPeriodType(request.getPeriodType());

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionCreationRequest.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionCreationRequest.java
@@ -19,6 +19,7 @@ package com.broadleafcommerce.subscriptionoperation.web.domain;
 import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionAdjustment;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionItem;
+import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionSourceType;
 import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultUserRefTypes;
 import com.broadleafcommerce.subscriptionoperation.domain.enums.SubscriptionStatuses;
 
@@ -107,19 +108,38 @@ public class SubscriptionCreationRequest implements Serializable {
     private String alternateUserRef;
 
     /**
-     * This field shows from which process or user action this subscription originated
+     * This field shows from which process or user action this subscription originated.
+     *
+     * @see #subscriptionSourceRef
+     * @see DefaultSubscriptionSourceType
      */
     private String subscriptionSource;
 
     /**
-     * This field shows the identifier of the process or user action this subscription originated
+     * This field shows the identifier of the process or user action this subscription originated.
+     *
+     * @see #subscriptionSource
      */
     private String subscriptionSourceRef;
 
     /**
+     * The type of the secondary source to reference, e.g, an Order Item on an Order. Optional.
+     *
+     * @see #secondarySourceRef
+     * @see DefaultSubscriptionSourceType
+     */
+    private String secondarySourceType;
+
+    /**
+     * The secondary source to reference, e.g, an Order Item on an Order. Optional.
+     *
+     * @see #secondarySourceType
+     */
+    private String secondarySourceRef;
+
+    /**
      * Frequency of billing for this subscription
      *
-     * @see com.broadleafcommerce.subscription.domain.DefaultSubscriptionBillingFrequencyEnum
      * @deprecated in favor of {@link #periodType} & {@link #periodFrequency}
      */
     @Deprecated


### PR DESCRIPTION
For BroadleafCommerce/MicroPM#5127

- We were using the wrong param name for page number and we should include _either_ page number _or_ offset not both. If we include offset, then we end up with an unnumbered page returned, which is not what we want for Subscriptions. So added a check that if the caller didn't pass offset, then we shouldn't pass offset to Billing.
- Introduce the ability to declare a secondary source reference (e.g. referencing an order item, while the primary `subscriptionSource` & `subscriptionSourceRef` point to the order)