### PR TITLE
Add subscription action domains and endpoints

### DIFF
--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/Product.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/Product.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2024 Broadleaf Commerce
+ *
+ * Licensed under the Broadleaf End User License Agreement (EULA), Version 1.1 (the
+ * "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt).
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the
+ * "Custom License") between you and Broadleaf Commerce. You may not use this file except in
+ * compliance with the applicable license.
+ *
+ * NOTICE: All information contained herein is, and remains the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained herein are proprietary to Broadleaf Commerce,
+ * LLC and may be covered by U.S. and Foreign Patents, patents in process, and are protected by
+ * trade secret or copyright law. Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
+ */
+package com.broadleafcommerce.subscriptionoperation.domain;
+
+import com.broadleafcommerce.data.tracking.core.ContextStateAware;
+import com.broadleafcommerce.data.tracking.core.filtering.business.domain.ContextState;
+import com.broadleafcommerce.data.tracking.core.filtering.domain.Tracking;
+import com.broadleafcommerce.money.CurrencyConsumer;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+import javax.money.CurrencySupplier;
+import javax.money.CurrencyUnit;
+
+import lombok.Data;
+
+/**
+ * The product containing the details related to subscriptions.
+ *
+ * @author Sunny Yu
+ */
+@Data
+public class Product
+        implements Serializable, ContextStateAware, CurrencySupplier, CurrencyConsumer {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The id of the product.
+     */
+    private String id;
+
+    /**
+     * Name of this product.
+     */
+    private String name;
+
+    /**
+     * Currency for all of the prices on this product
+     */
+    private CurrencyUnit currency;
+
+    /**
+     * The id of the product that this product can upgrade to.
+     */
+    private String upgradeProductId;
+
+    /**
+     * The id of the product that this product can downgrade to.
+     */
+    private String downgradeProductId;
+
+    /**
+     * The number of days after which a quantity decrease is not allowed. {@code null} means no
+     * restriction.
+     */
+    private Integer restrictDowngradeAfterDays;
+
+    /**
+     * The max number of active subscriptions that can be created for this product. {@code null}
+     * means no restriction.
+     */
+    private Integer maxNumberOfActiveSubscriptions;
+
+    /**
+     * A subset of {@link Tracking} information to expose the context state for this object.
+     *
+     * @param contextState a subset of {@link Tracking} information to expose the context state for
+     *        this object
+     * @return a subset of {@link Tracking} information to expose the context state for this object
+     */
+    private ContextState contextState;
+}

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/Product.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/Product.java
@@ -20,9 +20,14 @@ import com.broadleafcommerce.data.tracking.core.ContextStateAware;
 import com.broadleafcommerce.data.tracking.core.filtering.business.domain.ContextState;
 import com.broadleafcommerce.data.tracking.core.filtering.domain.Tracking;
 import com.broadleafcommerce.money.CurrencyConsumer;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.money.CurrencySupplier;
 import javax.money.CurrencyUnit;
@@ -86,4 +91,33 @@ public class Product
      * @return a subset of {@link Tracking} information to expose the context state for this object
      */
     private ContextState contextState;
+
+    /**
+     * Map holding any additional attributes passed in the request not matching any defined
+     * properties.
+     */
+    @JsonIgnore
+    private Map<String, Object> attributes = new HashMap<>();
+
+    /**
+     * Takes in any additional attributes passed in the request not matching any defined properties.
+     *
+     * @param name Name of the additional attribute
+     *
+     * @param value Value of the additional attribute
+     */
+    @JsonAnySetter
+    public void addAttribute(String name, Object value) {
+        attributes.put(name, value);
+    }
+
+    /**
+     * Return any additional attributes passed in the request not matching any defined properties.
+     *
+     * @return any additional attributes passed in the request not matching any defined properties.
+     */
+    @JsonAnyGetter
+    public Map<String, Object> getAttribute() {
+        return attributes;
+    }
 }

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/SubscriptionAction.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/SubscriptionAction.java
@@ -16,7 +16,7 @@
  */
 package com.broadleafcommerce.subscriptionoperation.domain;
 
-import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes;
+import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionType;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -39,7 +39,7 @@ public class SubscriptionAction implements Serializable {
     /**
      * The type of action.
      *
-     * @see DefaultSubscriptionActionTypes
+     * @see DefaultSubscriptionActionType
      */
     private String actionType;
 

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/SubscriptionAction.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/SubscriptionAction.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024 Broadleaf Commerce
+ *
+ * Licensed under the Broadleaf End User License Agreement (EULA), Version 1.1 (the
+ * "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt).
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the
+ * "Custom License") between you and Broadleaf Commerce. You may not use this file except in
+ * compliance with the applicable license.
+ *
+ * NOTICE: All information contained herein is, and remains the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained herein are proprietary to Broadleaf Commerce,
+ * LLC and may be covered by U.S. and Foreign Patents, patents in process, and are protected by
+ * trade secret or copyright law. Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
+ */
+package com.broadleafcommerce.subscriptionoperation.domain;
+
+import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.Data;
+
+/**
+ * Represents an action that can be taken against a {@link Subscription}.
+ *
+ * @author Sunny Yu
+ */
+@Data
+public class SubscriptionAction implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The type of action.
+     *
+     * @see DefaultSubscriptionActionTypes
+     */
+    private String actionType;
+
+    /**
+     * A map that may contain additional information about the action.
+     */
+    private Map<String, Object> actionInfo = new HashMap<>();
+}

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/SubscriptionWithItems.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/SubscriptionWithItems.java
@@ -16,7 +16,7 @@
  */
 package com.broadleafcommerce.subscriptionoperation.domain;
 
-import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes;
+import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionType;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -50,7 +50,7 @@ public class SubscriptionWithItems {
     private List<SubscriptionAction> availableActions = new ArrayList<>();
 
     /**
-     * The unavailable {@link DefaultSubscriptionActionTypes SubscriptionActionTypes} along with
+     * The unavailable {@link DefaultSubscriptionActionType SubscriptionActionTypes} along with
      * unavailable reasons for this subscription.
      */
     private Map<String, List<String>> unavailableReasonsByActionType = new HashMap<>();

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/SubscriptionWithItems.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/SubscriptionWithItems.java
@@ -16,8 +16,8 @@
  */
 package com.broadleafcommerce.subscriptionoperation.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.ArrayList;

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/SubscriptionWithItems.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/SubscriptionWithItems.java
@@ -17,10 +17,13 @@
 package com.broadleafcommerce.subscriptionoperation.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -40,6 +43,16 @@ public class SubscriptionWithItems {
 
     private List<SubscriptionItem> subscriptionItems = new ArrayList<>();
 
-    // TODO: Add list of available SubscriptionActions
+    /**
+     * The available {@link SubscriptionAction SubscriptionActions} that may be possible for this
+     * subscription.
+     */
+    private List<SubscriptionAction> availableActions = new ArrayList<>();
+
+    /**
+     * The unavailable {@link DefaultSubscriptionActionTypes SubscriptionActionTypes} along with
+     * unavailable reasons for this subscription.
+     */
+    private Map<String, List<String>> unavailableReasonsByActionType = new HashMap<>();
 
 }

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/enums/DefaultSubscriptionActionType.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/enums/DefaultSubscriptionActionType.java
@@ -23,7 +23,7 @@ import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
  *
  * @author Sunny Yu
  */
-public enum DefaultSubscriptionActionTypes {
+public enum DefaultSubscriptionActionType {
 
     /**
      * Whether the user can edit this subscription.

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/enums/DefaultSubscriptionActionTypes.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/enums/DefaultSubscriptionActionTypes.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2024 Broadleaf Commerce
+ *
+ * Licensed under the Broadleaf End User License Agreement (EULA), Version 1.1 (the
+ * "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt).
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the
+ * "Custom License") between you and Broadleaf Commerce. You may not use this file except in
+ * compliance with the applicable license.
+ *
+ * NOTICE: All information contained herein is, and remains the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained herein are proprietary to Broadleaf Commerce,
+ * LLC and may be covered by U.S. and Foreign Patents, patents in process, and are protected by
+ * trade secret or copyright law. Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
+ */
+package com.broadleafcommerce.subscriptionoperation.domain.enums;
+
+import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
+
+/**
+ * The default types of actions that can be taken against a {@link Subscription}.
+ *
+ * @author Sunny Yu
+ */
+public enum DefaultSubscriptionActionTypes {
+
+    /**
+     * Whether the user can edit this subscription.
+     */
+    EDIT,
+
+    /**
+     * Whether the user can change the auto-renewal value for this subscription.
+     */
+    CHANGE_AUTO_RENEWAL,
+
+    /**
+     * Whether the user can upgrade this subscription.
+     */
+    UPGRADE,
+
+    /**
+     * Whether the user can downgrade this subscription.
+     */
+    DOWNGRADE,
+
+    /**
+     * Whether the user can pause this subscription.
+     */
+    PAUSE,
+
+    /**
+     * Whether the user can resume this subscription.
+     */
+    RESUME,
+
+    /**
+     * Whether the user can suspend this subscription.
+     */
+    SUSPEND,
+
+    /**
+     * Whether the user can terminate this subscription.
+     */
+    TERMINATE,
+
+    /**
+     * Whether the user can reactivate this subscription.
+     */
+    REACTIVATE,
+
+    /**
+     * Whether the user can cancel this subscription.
+     */
+    CANCEL;
+
+    public static boolean isEdit(String type) {
+        return EDIT.name().equals(type);
+    }
+
+    public static boolean isChangeAutoRenewal(String type) {
+        return CHANGE_AUTO_RENEWAL.name().equals(type);
+    }
+
+    public static boolean isUpgrade(String type) {
+        return UPGRADE.name().equals(type);
+    }
+
+    public static boolean isDowngrade(String type) {
+        return DOWNGRADE.name().equals(type);
+    }
+
+    public static boolean isPause(String type) {
+        return PAUSE.name().equals(type);
+    }
+
+    public static boolean isResume(String type) {
+        return RESUME.name().equals(type);
+    }
+
+    public static boolean isSuspend(String type) {
+        return SUSPEND.name().equals(type);
+    }
+
+    public static boolean isTerminate(String type) {
+        return TERMINATE.name().equals(type);
+    }
+
+    public static boolean isReactivate(String type) {
+        return REACTIVATE.name().equals(type);
+    }
+
+    public static boolean isCancel(String type) {
+        return CANCEL.name().equals(type);
+    }
+}

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/enums/DefaultSubscriptionActionUnavailableReasons.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/enums/DefaultSubscriptionActionUnavailableReasons.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2024 Broadleaf Commerce
+ *
+ * Licensed under the Broadleaf End User License Agreement (EULA), Version 1.1 (the
+ * "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt).
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the
+ * "Custom License") between you and Broadleaf Commerce. You may not use this file except in
+ * compliance with the applicable license.
+ *
+ * NOTICE: All information contained herein is, and remains the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained herein are proprietary to Broadleaf Commerce,
+ * LLC and may be covered by U.S. and Foreign Patents, patents in process, and are protected by
+ * trade secret or copyright law. Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
+ */
+package com.broadleafcommerce.subscriptionoperation.domain.enums;
+
+import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
+
+/**
+ * The default reasons on why an action is unavailable for a {@link Subscription}.
+ *
+ * @see DefaultSubscriptionActionTypes
+ * @author Sunny Yu
+ */
+public enum DefaultSubscriptionActionUnavailableReasons {
+
+    /**
+     * The user doesn't have sufficient permissions to perform the action against this subscription.
+     */
+    INSUFFICIENT_PERMISSIONS,
+
+    /**
+     * There is no upgrade available for this subscription.
+     */
+    NO_UPGRADE_AVAILABLE,
+
+    /**
+     * There is no downgrade available for this subscription.
+     */
+    NO_DOWNGRADE_AVAILABLE,
+
+    /**
+     * A generic reason for something like can't change auto-renewal for subscriptions with
+     * multi-year terms.
+     */
+    ACTION_NOT_ALLOWED,
+
+    /**
+     * The subscription is in an incorrect state for the given action.
+     * <p>
+     * For example, you can only {@link DefaultSubscriptionActionTypes#RESUME RESUME} a
+     * {@link DefaultSubscriptionActionTypes#PAUSE PAUSED} subscription, and you can only
+     * {@link DefaultSubscriptionActionTypes#REACTIVATE REACTIVATE} a
+     * {@link DefaultSubscriptionActionTypes#TERMINATE TERMINATED} subscription.
+     */
+    INCORRECT_STATE;
+
+    public static boolean isInsufficientPermissions(String reason) {
+        return INSUFFICIENT_PERMISSIONS.name().equals(reason);
+    }
+
+    public static boolean isNoUpgradeAvailable(String reason) {
+        return NO_UPGRADE_AVAILABLE.name().equals(reason);
+    }
+
+    public static boolean isNoDowngradeAvailable(String reason) {
+        return NO_DOWNGRADE_AVAILABLE.name().equals(reason);
+    }
+
+    public static boolean isActionNotAllowed(String reason) {
+        return ACTION_NOT_ALLOWED.name().equals(reason);
+    }
+
+    public static boolean isIncorrectState(String reason) {
+        return INCORRECT_STATE.name().equals(reason);
+    }
+}

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/enums/DefaultSubscriptionActionUnavailableReasons.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/domain/enums/DefaultSubscriptionActionUnavailableReasons.java
@@ -21,7 +21,7 @@ import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
 /**
  * The default reasons on why an action is unavailable for a {@link Subscription}.
  *
- * @see DefaultSubscriptionActionTypes
+ * @see DefaultSubscriptionActionType
  * @author Sunny Yu
  */
 public enum DefaultSubscriptionActionUnavailableReasons {
@@ -50,10 +50,10 @@ public enum DefaultSubscriptionActionUnavailableReasons {
     /**
      * The subscription is in an incorrect state for the given action.
      * <p>
-     * For example, you can only {@link DefaultSubscriptionActionTypes#RESUME RESUME} a
-     * {@link DefaultSubscriptionActionTypes#PAUSE PAUSED} subscription, and you can only
-     * {@link DefaultSubscriptionActionTypes#REACTIVATE REACTIVATE} a
-     * {@link DefaultSubscriptionActionTypes#TERMINATE TERMINATED} subscription.
+     * For example, you can only {@link DefaultSubscriptionActionType#RESUME RESUME} a
+     * {@link DefaultSubscriptionActionType#PAUSE PAUSED} subscription, and you can only
+     * {@link DefaultSubscriptionActionType#REACTIVATE REACTIVATE} a
+     * {@link DefaultSubscriptionActionType#TERMINATE TERMINATED} subscription.
      */
     INCORRECT_STATE;
 

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionOperationService.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionOperationService.java
@@ -28,7 +28,7 @@ import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionAction;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionItem;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionWithItems;
-import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes;
+import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionType;
 import com.broadleafcommerce.subscriptionoperation.service.provider.SubscriptionProvider;
 import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionActionRequest;
 import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionActionResponse;
@@ -166,14 +166,14 @@ public class DefaultSubscriptionOperationService<S extends Subscription, I exten
     }
 
     protected List<String> getAllActionTypes() {
-        return Arrays.stream(DefaultSubscriptionActionTypes.values())
+        return Arrays.stream(DefaultSubscriptionActionType.values())
                 .map(Enum::name)
                 .toList();
     }
 
     protected void populateActionAvailability(SWI subscription, String actionType) {
         // TODO: Add actual logic
-        if (!DefaultSubscriptionActionTypes.isDowngrade(actionType)) {
+        if (!DefaultSubscriptionActionType.isDowngrade(actionType)) {
             subscription.getAvailableActions().add(buildAvailableAction(actionType));
         } else {
             subscription.getUnavailableReasonsByActionType().put(actionType,

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionOperationService.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionOperationService.java
@@ -68,7 +68,8 @@ public class DefaultSubscriptionOperationService<S extends Subscription, I exten
             @NonNull SubscriptionActionRequest request,
             @Nullable ContextInfo contextInfo) {
         SWI subscription =
-                subscriptionProvider.readSubscriptionById(request.getSubscriptionId(), contextInfo);
+                subscriptionProvider.readUserSubscriptionById(request.getUserRefType(),
+                        request.getUserRef(), request.getSubscriptionId(), contextInfo);
 
         populateSubscriptionActions(subscription, contextInfo);
 

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionOperationService.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionOperationService.java
@@ -16,9 +16,7 @@
  */
 package com.broadleafcommerce.subscriptionoperation.service;
 
-import static com.broadleafcommerce.data.tracking.core.filtering.fetch.rsql.RsqlSearchOperation.EQUAL;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,7 +24,6 @@ import org.springframework.lang.Nullable;
 
 import com.broadleafcommerce.common.extension.TypeFactory;
 import com.broadleafcommerce.data.tracking.core.context.ContextInfo;
-import com.broadleafcommerce.data.tracking.core.exception.EntityMissingException;
 import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionAction;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionItem;
@@ -45,7 +42,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import cz.jirutka.rsql.parser.ast.ComparisonNode;
 import cz.jirutka.rsql.parser.ast.Node;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -71,39 +67,28 @@ public class DefaultSubscriptionOperationService<S extends Subscription, I exten
     public SubscriptionActionResponse readSubscriptionActions(
             @NonNull SubscriptionActionRequest request,
             @Nullable ContextInfo contextInfo) {
-        Node idFilter = buildSubscriptionIdFilter(request.getSubscriptionId(), contextInfo);
+        SWI subscription =
+                subscriptionProvider.readSubscriptionById(request.getSubscriptionId(), contextInfo);
 
-        List<SWI> subscriptions = subscriptionProvider.readSubscriptionsForUserTypeAndUserId(
-                request.getUserType(), request.getUserId(),
-                Pageable.unpaged(), idFilter, contextInfo)
-                .getContent();
-
-        if (CollectionUtils.isEmpty(subscriptions)) {
-            throw new EntityMissingException();
-        } else if (subscriptions.size() > 1) {
-            log.warn(
-                    "There is more than 1 subscription with the same id for the user type and id. (userType: {} | userId: {} | subscriptionId: {})",
-                    request.getUserType(), request.getUserId(), request.getSubscriptionId());
-        }
-
-        populateSubscriptionActions(subscriptions, contextInfo);
+        populateSubscriptionActions(subscription, contextInfo);
 
         SubscriptionActionResponse response = typeFactory.get(SubscriptionActionResponse.class);
-        response.setAvailableActions(subscriptions.get(0).getAvailableActions());
+        response.setAvailableActions(subscription.getAvailableActions());
         response.setUnavailableReasonsByActionType(
-                subscriptions.get(0).getUnavailableReasonsByActionType());
+                subscription.getUnavailableReasonsByActionType());
         return response;
     }
 
     @Override
     public Page<SWI> readSubscriptionsForUserRefTypeAndUserRef(@lombok.NonNull String userRefType,
             @lombok.NonNull String userRef,
-                                                               boolean getActions,
+            boolean getActions,
             @Nullable Pageable page,
             @Nullable Node filters,
             @Nullable ContextInfo contextInfo) {
         Page<SWI> subscriptions =
-                subscriptionProvider.readSubscriptionsForUserRefTypeAndUserRef(userRefType, userRef, getActions, page,
+                subscriptionProvider.readSubscriptionsForUserRefTypeAndUserRef(userRefType, userRef,
+                        page,
                         filters, contextInfo);
         if (getActions) {
             populateSubscriptionActions(subscriptions, contextInfo);
@@ -116,9 +101,15 @@ public class DefaultSubscriptionOperationService<S extends Subscription, I exten
     public SWI readUserSubscriptionById(@lombok.NonNull String userRefType,
             @lombok.NonNull String userRef,
             @lombok.NonNull String subscriptionId,
+            boolean getActions,
             @Nullable ContextInfo contextInfo) {
-        return subscriptionProvider.readUserSubscriptionById(userRefType, userRef, subscriptionId,
-                contextInfo);
+        SWI subscription =
+                subscriptionProvider.readUserSubscriptionById(userRefType, userRef, subscriptionId,
+                        contextInfo);
+        if (getActions) {
+            populateSubscriptionActions(subscription, contextInfo);
+        }
+        return subscription;
     }
 
     @Override
@@ -164,10 +155,13 @@ public class DefaultSubscriptionOperationService<S extends Subscription, I exten
 
     protected void populateSubscriptionActions(Iterable<SWI> subscriptions,
             @Nullable ContextInfo contextInfo) {
-        List<String> actionTypes = getAllActionTypes();
-        subscriptions.forEach(subscription -> {
-            actionTypes.forEach(action -> populateActionAvailability(subscription, action));
-        });
+        subscriptions
+                .forEach(subscription -> populateSubscriptionActions(subscription, contextInfo));
+    }
+
+    protected void populateSubscriptionActions(SWI subscription,
+            @Nullable ContextInfo contextInfo) {
+        getAllActionTypes().forEach(action -> populateActionAvailability(subscription, action));
     }
 
     protected List<String> getAllActionTypes() {
@@ -257,12 +251,5 @@ public class DefaultSubscriptionOperationService<S extends Subscription, I exten
         }
 
         return items;
-    }
-
-    protected Node buildSubscriptionIdFilter(@lombok.NonNull String subscriptionId,
-            @Nullable ContextInfo contextInfo) {
-        return new ComparisonNode(EQUAL.getOperator(),
-                "id",
-                List.of(subscriptionId));
     }
 }

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionValidationService.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionValidationService.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2024 Broadleaf Commerce
+ *
+ * Licensed under the Broadleaf End User License Agreement (EULA), Version 1.1 (the
+ * "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt).
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the
+ * "Custom License") between you and Broadleaf Commerce. You may not use this file except in
+ * compliance with the applicable license.
+ *
+ * NOTICE: All information contained herein is, and remains the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained herein are proprietary to Broadleaf Commerce,
+ * LLC and may be covered by U.S. and Foreign Patents, patents in process, and are protected by
+ * trade secret or copyright law. Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
+ */
+package com.broadleafcommerce.subscriptionoperation.service;
+
+import static com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes.CANCEL;
+import static com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes.DOWNGRADE;
+import static com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes.UPGRADE;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.Nullable;
+
+import com.broadleafcommerce.data.tracking.core.context.ContextInfo;
+import com.broadleafcommerce.data.tracking.core.policy.PolicyResponse;
+import com.broadleafcommerce.data.tracking.core.policy.trackable.TrackablePolicyUtils;
+import com.broadleafcommerce.subscriptionoperation.domain.Product;
+import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes;
+import com.broadleafcommerce.subscriptionoperation.service.exception.InsufficientSubscriptionAccessException;
+import com.broadleafcommerce.subscriptionoperation.service.exception.InvalidSubscriptionCreationRequestException;
+import com.broadleafcommerce.subscriptionoperation.service.exception.InvalidSubscriptionDowngradeRequestException;
+import com.broadleafcommerce.subscriptionoperation.service.exception.InvalidSubscriptionUpgradeRequestException;
+import com.broadleafcommerce.subscriptionoperation.service.provider.CatalogProvider;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionCancellationRequest;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionCreationRequest;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionDowngradeRequest;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionUpgradeRequest;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class DefaultSubscriptionValidationService implements SubscriptionValidationService {
+
+    @Getter(AccessLevel.PROTECTED)
+    private final CatalogProvider<Product> catalogProvider;
+
+    @Getter(value = AccessLevel.PROTECTED, onMethod_ = @Nullable)
+    @Setter(onMethod_ = @Autowired(required = false))
+    private TrackablePolicyUtils policyUtils;
+
+    @Override
+    public void validateSubscriptionCreation(
+            @lombok.NonNull SubscriptionCreationRequest creationRequest,
+            @Nullable ContextInfo contextInfo) {
+        if (StringUtils.isBlank(creationRequest.getUserRefType())
+                || StringUtils.isBlank(creationRequest.getUserRef())) {
+            throw new InvalidSubscriptionCreationRequestException(
+                    "A subscription must be given an owning user/account via userRefType and userRef.");
+        }
+        if (StringUtils.isBlank(creationRequest.getPeriodType())
+                && StringUtils.isBlank(creationRequest.getBillingFrequency())) {
+            throw new InvalidSubscriptionCreationRequestException(
+                    "A subscription must be given a periodType or billingFrequency.");
+        }
+        if (CollectionUtils.isEmpty(creationRequest.getItemCreationRequests())) {
+            throw new InvalidSubscriptionCreationRequestException(
+                    "Subscription items must also be defined for the subscription.");
+        }
+    }
+
+    @Override
+    public void validateSubscriptionCancellation(
+            @lombok.NonNull SubscriptionCancellationRequest cancellationRequest,
+            @Nullable ContextInfo contextInfo) {
+        validateUserAccessToSubscription(cancellationRequest.getSubscriptionId(), CANCEL.name(),
+                contextInfo);
+        // TODO Implement this method
+        validateBusinessRules(cancellationRequest.getSubscriptionId(), CANCEL.name(), contextInfo);
+    }
+
+    @Override
+    public void validateSubscriptionUpgrade(
+            @lombok.NonNull SubscriptionUpgradeRequest upgradeRequest,
+            @Nullable ContextInfo contextInfo) {
+        validateUserAccessToSubscription(upgradeRequest.getPriorSubscriptionId(), UPGRADE.name(),
+                contextInfo);
+        // TODO Implement this method
+        Product product = catalogProvider.readProductById("productId", contextInfo);
+        // validate upgrade eligibility
+        if (StringUtils.isBlank(product.getUpgradeProductId())) {
+            throw new InvalidSubscriptionUpgradeRequestException(
+                    "The subscription is not eligible for an upgrade.");
+        }
+        validateBusinessRules(upgradeRequest.getPriorSubscriptionId(), UPGRADE.name(), contextInfo);
+    }
+
+    @Override
+    public void validateSubscriptionDowngrade(
+            @lombok.NonNull SubscriptionDowngradeRequest downgradeRequest,
+            @Nullable ContextInfo contextInfo) {
+        validateUserAccessToSubscription(downgradeRequest.getPriorSubscriptionId(),
+                DOWNGRADE.name(), contextInfo);
+        // TODO Implement this method
+        Product product = catalogProvider.readProductById("productId", contextInfo);
+        // validate downgrade eligibility
+        if (StringUtils.isBlank(product.getDowngradeProductId())) {
+            throw new InvalidSubscriptionDowngradeRequestException(
+                    "The subscription is not eligible for an downgrade.");
+        }
+        validateBusinessRules(downgradeRequest.getPriorSubscriptionId(), DOWNGRADE.name(),
+                contextInfo);
+    }
+
+    // a ValidationDTO may be useful here.
+    protected void validateBusinessRules(String subscriptionId,
+            String actionType,
+            @Nullable ContextInfo contextInfo) {
+        // hook point
+    }
+
+    protected void validateUserAccessToSubscription(String subscriptionId,
+            String actionType,
+            @Nullable ContextInfo contextInfo) {
+        // TODO Will likely need components like AuthenticationVendorPrivilegesUtility &
+        // AuthenticationVendorPrivilegesSummary to validate permissions for each subscription
+        if (policyUtils != null) {
+            String[] permissionsRequired = getRequiredPermissions(actionType);
+            PolicyResponse permResponse =
+                    policyUtils.validatePermissions(permissionsRequired, contextInfo);
+            if (PolicyResponse.VALID.getState() != permResponse.getState()) {
+                throw new InsufficientSubscriptionAccessException(
+                        "You do not have access to perform this action against this subscription.");
+            }
+        } else {
+            log.warn(
+                    "PolicyUtils is not available to validate permissions. Permission check is skipped.");
+        }
+
+        validateAdditionalPermissionRules(subscriptionId, actionType, contextInfo);
+    }
+
+    protected String[] getRequiredPermissions(String actionType) {
+        // TODO Implement this method
+        if (DefaultSubscriptionActionTypes.isEdit(actionType)) {
+            return new String[] {"EDIT_SUBSCRIPTION"};
+        } else {
+            return new String[] {};
+        }
+    }
+
+    protected void validateAdditionalPermissionRules(String subscriptionId,
+            String actionType,
+            @Nullable ContextInfo contextInfo) {
+        // hookpoint
+    }
+}

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionValidationService.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionValidationService.java
@@ -16,9 +16,9 @@
  */
 package com.broadleafcommerce.subscriptionoperation.service;
 
-import static com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes.CANCEL;
-import static com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes.DOWNGRADE;
-import static com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes.UPGRADE;
+import static com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionType.CANCEL;
+import static com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionType.DOWNGRADE;
+import static com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionType.UPGRADE;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -29,7 +29,7 @@ import com.broadleafcommerce.data.tracking.core.context.ContextInfo;
 import com.broadleafcommerce.data.tracking.core.policy.PolicyResponse;
 import com.broadleafcommerce.data.tracking.core.policy.trackable.TrackablePolicyUtils;
 import com.broadleafcommerce.subscriptionoperation.domain.Product;
-import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes;
+import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionType;
 import com.broadleafcommerce.subscriptionoperation.service.exception.InsufficientSubscriptionAccessException;
 import com.broadleafcommerce.subscriptionoperation.service.exception.InvalidSubscriptionCreationRequestException;
 import com.broadleafcommerce.subscriptionoperation.service.exception.InvalidSubscriptionDowngradeRequestException;
@@ -132,6 +132,16 @@ public class DefaultSubscriptionValidationService implements SubscriptionValidat
         // hook point
     }
 
+    /**
+     * Validates the user's access to the subscription.
+     *
+     * @param subscriptionId the id of the subscription being accessed
+     * @param actionType the type of action being taken against the subscription. See
+     *        {@link DefaultSubscriptionActionType}
+     * @param contextInfo the current context
+     * @throws InsufficientSubscriptionAccessException if the user does not have access to the
+     *         subscription
+     */
     protected void validateUserAccessToSubscription(String subscriptionId,
             String actionType,
             @Nullable ContextInfo contextInfo) {
@@ -155,7 +165,7 @@ public class DefaultSubscriptionValidationService implements SubscriptionValidat
 
     protected String[] getRequiredPermissions(String actionType) {
         // TODO Implement this method
-        if (DefaultSubscriptionActionTypes.isEdit(actionType)) {
+        if (DefaultSubscriptionActionType.isEdit(actionType)) {
             return new String[] {"EDIT_SUBSCRIPTION"};
         } else {
             return new String[] {};

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionValidationService.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionValidationService.java
@@ -71,6 +71,11 @@ public class DefaultSubscriptionValidationService implements SubscriptionValidat
             throw new InvalidSubscriptionCreationRequestException(
                     "A subscription must be given a periodType or billingFrequency.");
         }
+        if (StringUtils.isBlank(creationRequest.getSubscriptionSource())
+                && StringUtils.isBlank(creationRequest.getSubscriptionSourceRef())) {
+            throw new InvalidSubscriptionCreationRequestException(
+                    "A subscription must be given a source or sourceRef.");
+        }
         if (CollectionUtils.isEmpty(creationRequest.getItemCreationRequests())) {
             throw new InvalidSubscriptionCreationRequestException(
                     "Subscription items must also be defined for the subscription.");

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/SubscriptionOperationService.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/SubscriptionOperationService.java
@@ -112,4 +112,14 @@ public interface SubscriptionOperationService<S extends Subscription, I extends 
      */
     S upgradeSubscription(SubscriptionUpgradeRequest upgradeRequest,
             @Nullable ContextInfo contextInfo);
+
+    /**
+     * TODO
+     *
+     * @param downgradeRequest
+     * @param contextInfo
+     * @return
+     */
+    S downgradeSubscription(SubscriptionDowngradeRequest downgradeRequest,
+            @Nullable ContextInfo contextInfo);
 }

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/SubscriptionOperationService.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/SubscriptionOperationService.java
@@ -28,6 +28,7 @@ import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionWithItems;
 import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultUserRefTypes;
 import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionCancellationRequest;
 import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionCreationRequest;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionDowngradeRequest;
 import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionUpgradeRequest;
 
 import cz.jirutka.rsql.parser.ast.Node;
@@ -43,6 +44,7 @@ public interface SubscriptionOperationService<S extends Subscription, I extends 
      *
      * @param userRefType user type, see {@link DefaultUserRefTypes}
      * @param userRef id of owning user or account
+     * @param getActions whether to get available actions for the subscriptions
      * @param page information about which page of results to return from the database.
      * @param filters additional filters to apply in the query. Should be {@link EmptyNode} if no
      *        additional filters should be applied.
@@ -51,6 +53,7 @@ public interface SubscriptionOperationService<S extends Subscription, I extends 
      */
     Page<SWI> readSubscriptionsForUserRefTypeAndUserRef(String userRefType,
             String userRef,
+            boolean getActions,
             @Nullable Pageable page,
             @Nullable Node filters,
             @Nullable ContextInfo contextInfo);

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/SubscriptionOperationService.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/SubscriptionOperationService.java
@@ -26,6 +26,8 @@ import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionItem;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionWithItems;
 import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultUserRefTypes;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionActionRequest;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionActionResponse;
 import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionCancellationRequest;
 import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionCreationRequest;
 import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionDowngradeRequest;
@@ -37,6 +39,17 @@ import cz.jirutka.rsql.parser.ast.Node;
  * Service for operations on subscriptions and their items
  */
 public interface SubscriptionOperationService<S extends Subscription, I extends SubscriptionItem, SWI extends SubscriptionWithItems> {
+
+    /**
+     * This method reads subscriptions for a given user type and user id, additionally filtered and
+     * paginated by given parameters
+     *
+     * @param request the {@link SubscriptionActionRequest}
+     * @param contextInfo context information around multi-tenant state
+     * @return Subscriptions with items matching the given criteria
+     */
+    SubscriptionActionResponse readSubscriptionActions(SubscriptionActionRequest request,
+            @Nullable ContextInfo contextInfo);
 
     /**
      * This method reads subscriptions for a given user type and user id, additionally filtered and

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/SubscriptionOperationService.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/SubscriptionOperationService.java
@@ -78,12 +78,14 @@ public interface SubscriptionOperationService<S extends Subscription, I extends 
      * @param userRefType user type, see {@link DefaultUserRefTypes}
      * @param userRef id of owning user or account
      * @param subscriptionId The id of the {@link Subscription} that is intended to be gathered
+     * @param getActions whether to get available actions for the subscription
      * @param contextInfo context information around multi-tenant state
      * @return Subscriptions with items matching the given criteria
      */
     SWI readUserSubscriptionById(String userRefType,
             String userRef,
             String subscriptionId,
+            boolean getActions,
             @Nullable ContextInfo contextInfo);
 
     /**

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/SubscriptionValidationService.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/SubscriptionValidationService.java
@@ -14,43 +14,33 @@
  * trade secret or copyright law. Dissemination of this information or reproduction of this material
  * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
  */
-package com.broadleafcommerce.subscriptionoperation.service.provider;
+package com.broadleafcommerce.subscriptionoperation.service;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.lang.Nullable;
 
 import com.broadleafcommerce.data.tracking.core.context.ContextInfo;
-import com.broadleafcommerce.subscriptionoperation.domain.Product;
-import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionCancellationRequest;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionCreationRequest;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionDowngradeRequest;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionUpgradeRequest;
 
-import java.util.List;
 
 /**
- * Provider interfacing with Broadleaf's CatalogServices to get the product details for the
- * {@link Subscription}.
+ * Service for validating actions against subscriptions.
+ *
+ * @author Sunny Yu
  */
-public interface CatalogProvider<P extends Product> {
+public interface SubscriptionValidationService {
 
-    /**
-     * Retrieves the {@link Product} based on the given id.
-     *
-     * @param productId the product id
-     * @param contextInfo context information around multi-tenant state
-     * @return the {@link Product}
-     */
-    P readProductById(String productId,
+    void validateSubscriptionCreation(SubscriptionCreationRequest request,
             @Nullable ContextInfo contextInfo);
 
-    /**
-     * Retrieves {@link Product Products} based on the given ids.
-     *
-     * @param productIds list of product ids
-     * @param pageable pageable
-     * @param contextInfo context information around multi-tenant state
-     * @return page of {@link Product Products}
-     */
-    Page<P> readProductsByIds(List<String> productIds,
-            @Nullable Pageable pageable,
+    void validateSubscriptionCancellation(SubscriptionCancellationRequest request,
+            @Nullable ContextInfo contextInfo);
+
+    void validateSubscriptionUpgrade(SubscriptionUpgradeRequest request,
+            @Nullable ContextInfo contextInfo);
+
+    void validateSubscriptionDowngrade(SubscriptionDowngradeRequest request,
             @Nullable ContextInfo contextInfo);
 }

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/SubscriptionValidationService.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/SubscriptionValidationService.java
@@ -19,6 +19,10 @@ package com.broadleafcommerce.subscriptionoperation.service;
 import org.springframework.lang.Nullable;
 
 import com.broadleafcommerce.data.tracking.core.context.ContextInfo;
+import com.broadleafcommerce.subscriptionoperation.service.exception.InsufficientSubscriptionAccessException;
+import com.broadleafcommerce.subscriptionoperation.service.exception.InvalidSubscriptionCreationRequestException;
+import com.broadleafcommerce.subscriptionoperation.service.exception.InvalidSubscriptionDowngradeRequestException;
+import com.broadleafcommerce.subscriptionoperation.service.exception.InvalidSubscriptionUpgradeRequestException;
 import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionCancellationRequest;
 import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionCreationRequest;
 import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionDowngradeRequest;
@@ -32,15 +36,48 @@ import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionUpgrad
  */
 public interface SubscriptionValidationService {
 
+    /**
+     * Validates the creation of a subscription.
+     *
+     * @param request the {@link SubscriptionCreationRequest}
+     * @param contextInfo context information around multitenant state
+     * @throws InvalidSubscriptionCreationRequestException if the request is invalid
+     */
     void validateSubscriptionCreation(SubscriptionCreationRequest request,
             @Nullable ContextInfo contextInfo);
 
+    /**
+     * Validates the cancellation of a subscription.
+     *
+     * @param request the {@link SubscriptionCancellationRequest}
+     * @param contextInfo context information around multitenant state
+     * @throws InsufficientSubscriptionAccessException if the user does not have access to the
+     *         subscription
+     */
     void validateSubscriptionCancellation(SubscriptionCancellationRequest request,
             @Nullable ContextInfo contextInfo);
 
+    /**
+     * Validates the upgrade of a subscription.
+     *
+     * @param request the {@link SubscriptionUpgradeRequest}
+     * @param contextInfo context information around multitenant state
+     * @throws InsufficientSubscriptionAccessException if the user does not have access to the
+     *         subscription
+     * @throws InvalidSubscriptionUpgradeRequestException if the request is invalid
+     */
     void validateSubscriptionUpgrade(SubscriptionUpgradeRequest request,
             @Nullable ContextInfo contextInfo);
 
+    /**
+     * Validates the downgrade of a subscription.
+     *
+     * @param request the {@link SubscriptionDowngradeRequest}
+     * @param contextInfo context information around multitenant state
+     * @throws InsufficientSubscriptionAccessException if the user does not have access to the
+     *         subscription
+     * @throws InvalidSubscriptionDowngradeRequestException if the request is invalid
+     */
     void validateSubscriptionDowngrade(SubscriptionDowngradeRequest request,
             @Nullable ContextInfo contextInfo);
 }

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/autoconfigure/SubscriptionOperationServiceAutoConfiguration.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/autoconfigure/SubscriptionOperationServiceAutoConfiguration.java
@@ -24,12 +24,16 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import com.broadleafcommerce.common.extension.TypeFactory;
+import com.broadleafcommerce.subscriptionoperation.domain.Product;
 import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionItem;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionWithItems;
 import com.broadleafcommerce.subscriptionoperation.service.DefaultSubscriptionOperationService;
 import com.broadleafcommerce.subscriptionoperation.service.SubscriptionOperationService;
+import com.broadleafcommerce.subscriptionoperation.service.provider.CatalogProvider;
 import com.broadleafcommerce.subscriptionoperation.service.provider.SubscriptionProvider;
+import com.broadleafcommerce.subscriptionoperation.service.provider.external.ExternalCatalogProvider;
+import com.broadleafcommerce.subscriptionoperation.service.provider.external.ExternalCatalogProviderProperties;
 import com.broadleafcommerce.subscriptionoperation.service.provider.external.ExternalSubscriptionProperties;
 import com.broadleafcommerce.subscriptionoperation.service.provider.external.ExternalSubscriptionProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -47,7 +51,8 @@ public class SubscriptionOperationServiceAutoConfiguration {
     }
 
     @Configuration
-    @EnableConfigurationProperties({ExternalSubscriptionProperties.class})
+    @EnableConfigurationProperties({ExternalSubscriptionProperties.class,
+            ExternalCatalogProviderProperties.class})
     public static class SubscriptionProviderConfiguration {
         @Bean
         @ConditionalOnMissingBean
@@ -57,6 +62,19 @@ public class SubscriptionOperationServiceAutoConfiguration {
                 TypeFactory typeFactory,
                 ExternalSubscriptionProperties properties) {
             return new ExternalSubscriptionProvider<>(webClient,
+                    objectMapper,
+                    typeFactory,
+                    properties);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public CatalogProvider<Product> catalogProvider(
+                @Qualifier("subscriptionOperationWebClient") WebClient webClient,
+                ObjectMapper objectMapper,
+                TypeFactory typeFactory,
+                ExternalCatalogProviderProperties properties) {
+            return new ExternalCatalogProvider<>(webClient,
                     objectMapper,
                     typeFactory,
                     properties);

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/autoconfigure/SubscriptionOperationServiceAutoConfiguration.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/autoconfigure/SubscriptionOperationServiceAutoConfiguration.java
@@ -29,6 +29,7 @@ import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionItem;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionWithItems;
 import com.broadleafcommerce.subscriptionoperation.service.DefaultSubscriptionOperationService;
+import com.broadleafcommerce.subscriptionoperation.service.DefaultSubscriptionValidationService;
 import com.broadleafcommerce.subscriptionoperation.service.SubscriptionOperationService;
 import com.broadleafcommerce.subscriptionoperation.service.provider.CatalogProvider;
 import com.broadleafcommerce.subscriptionoperation.service.provider.SubscriptionProvider;
@@ -46,8 +47,11 @@ public class SubscriptionOperationServiceAutoConfiguration {
     @ConditionalOnMissingBean
     public SubscriptionOperationService<Subscription, SubscriptionItem, SubscriptionWithItems> subscriptionOperationService(
             SubscriptionProvider<SubscriptionWithItems> subscriptionProvider,
+            DefaultSubscriptionValidationService subscriptionValidationService,
             TypeFactory typeFactory) {
-        return new DefaultSubscriptionOperationService<>(subscriptionProvider, typeFactory);
+        return new DefaultSubscriptionOperationService<>(subscriptionProvider,
+                subscriptionValidationService,
+                typeFactory);
     }
 
     @Configuration

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/autoconfigure/SubscriptionOperationServiceAutoConfiguration.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/autoconfigure/SubscriptionOperationServiceAutoConfiguration.java
@@ -31,6 +31,7 @@ import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionWithItems;
 import com.broadleafcommerce.subscriptionoperation.service.DefaultSubscriptionOperationService;
 import com.broadleafcommerce.subscriptionoperation.service.DefaultSubscriptionValidationService;
 import com.broadleafcommerce.subscriptionoperation.service.SubscriptionOperationService;
+import com.broadleafcommerce.subscriptionoperation.service.SubscriptionValidationService;
 import com.broadleafcommerce.subscriptionoperation.service.provider.CatalogProvider;
 import com.broadleafcommerce.subscriptionoperation.service.provider.SubscriptionProvider;
 import com.broadleafcommerce.subscriptionoperation.service.provider.external.ExternalCatalogProvider;
@@ -45,9 +46,16 @@ public class SubscriptionOperationServiceAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    public SubscriptionValidationService subscriptionValidationService(
+            CatalogProvider<Product> catalogProvider) {
+        return new DefaultSubscriptionValidationService(catalogProvider);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
     public SubscriptionOperationService<Subscription, SubscriptionItem, SubscriptionWithItems> subscriptionOperationService(
             SubscriptionProvider<SubscriptionWithItems> subscriptionProvider,
-            DefaultSubscriptionValidationService subscriptionValidationService,
+            SubscriptionValidationService subscriptionValidationService,
             TypeFactory typeFactory) {
         return new DefaultSubscriptionOperationService<>(subscriptionProvider,
                 subscriptionValidationService,
@@ -73,7 +81,7 @@ public class SubscriptionOperationServiceAutoConfiguration {
 
         @Bean
         @ConditionalOnMissingBean
-        public CatalogProvider<Product> catalogProvider(
+        public CatalogProvider<Product> subOpsCatalogProvider(
                 @Qualifier("subscriptionOperationWebClient") WebClient webClient,
                 ObjectMapper objectMapper,
                 TypeFactory typeFactory,

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/exception/InsufficientSubscriptionAccessException.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/exception/InsufficientSubscriptionAccessException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2021 Broadleaf Commerce
+ *
+ * Licensed under the Broadleaf End User License Agreement (EULA), Version 1.1 (the
+ * "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt).
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the
+ * "Custom License") between you and Broadleaf Commerce. You may not use this file except in
+ * compliance with the applicable license.
+ *
+ * NOTICE: All information contained herein is, and remains the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained herein are proprietary to Broadleaf Commerce,
+ * LLC and may be covered by U.S. and Foreign Patents, patents in process, and are protected by
+ * trade secret or copyright law. Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
+ */
+package com.broadleafcommerce.subscriptionoperation.service.exception;
+
+/**
+ * Exception denoting that the user does not have sufficient access to the subscription.
+ *
+ * @author Sunny Yu
+ */
+public class InsufficientSubscriptionAccessException extends RuntimeException {
+
+    public InsufficientSubscriptionAccessException(String message) {
+        super(message);
+    }
+
+}

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/exception/InvalidSubscriptionDowngradeRequestException.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/exception/InvalidSubscriptionDowngradeRequestException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2021 Broadleaf Commerce
+ *
+ * Licensed under the Broadleaf End User License Agreement (EULA), Version 1.1 (the
+ * "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt).
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the
+ * "Custom License") between you and Broadleaf Commerce. You may not use this file except in
+ * compliance with the applicable license.
+ *
+ * NOTICE: All information contained herein is, and remains the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained herein are proprietary to Broadleaf Commerce,
+ * LLC and may be covered by U.S. and Foreign Patents, patents in process, and are protected by
+ * trade secret or copyright law. Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
+ */
+package com.broadleafcommerce.subscriptionoperation.service.exception;
+
+/**
+ * Exception denoting that the request to downgrade a subscription was invalid
+ *
+ * @author Chris Kittrell (ckittrell)
+ */
+public class InvalidSubscriptionDowngradeRequestException extends RuntimeException {
+
+    public InvalidSubscriptionDowngradeRequestException(String message) {
+        super(message);
+    }
+
+}

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/CatalogProvider.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/CatalogProvider.java
@@ -36,11 +36,11 @@ public interface CatalogProvider<P extends Product> {
      * Retrieves {@link Product Products} based on the given ids.
      *
      * @param productIds list of product ids
-     * @param page pageable
+     * @param pageable pageable
      * @param contextInfo context information around multi-tenant state
      * @return page of {@link Product Products}
      */
     Page<P> readProductsByIds(List<String> productIds,
-            @Nullable Pageable page,
+            @Nullable Pageable pageable,
             @Nullable ContextInfo contextInfo);
 }

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/CatalogProvider.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/CatalogProvider.java
@@ -29,6 +29,8 @@ import java.util.List;
 /**
  * Provider interfacing with Broadleaf's CatalogServices to get the product details for the
  * {@link Subscription}.
+ *
+ * @author Sunny Yu
  */
 public interface CatalogProvider<P extends Product> {
 
@@ -39,8 +41,7 @@ public interface CatalogProvider<P extends Product> {
      * @param contextInfo context information around multi-tenant state
      * @return the {@link Product}
      */
-    P readProductById(String productId,
-            @Nullable ContextInfo contextInfo);
+    P readProductById(String productId, @Nullable ContextInfo contextInfo);
 
     /**
      * Retrieves {@link Product Products} based on the given ids.

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/CatalogProvider.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/CatalogProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Broadleaf Commerce
+ *
+ * Licensed under the Broadleaf End User License Agreement (EULA), Version 1.1 (the
+ * "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt).
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the
+ * "Custom License") between you and Broadleaf Commerce. You may not use this file except in
+ * compliance with the applicable license.
+ *
+ * NOTICE: All information contained herein is, and remains the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained herein are proprietary to Broadleaf Commerce,
+ * LLC and may be covered by U.S. and Foreign Patents, patents in process, and are protected by
+ * trade secret or copyright law. Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
+ */
+package com.broadleafcommerce.subscriptionoperation.service.provider;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.lang.Nullable;
+
+import com.broadleafcommerce.data.tracking.core.context.ContextInfo;
+import com.broadleafcommerce.subscriptionoperation.domain.Product;
+import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
+
+import java.util.List;
+
+/**
+ * Provider interfacing with Broadleaf's CatalogServices to get the product details for the
+ * {@link Subscription}.
+ */
+public interface CatalogProvider<P extends Product> {
+
+    /**
+     * Retrieves {@link Product Products} based on the given ids.
+     *
+     * @param productIds list of product ids
+     * @param page pageable
+     * @param contextInfo context information around multi-tenant state
+     * @return page of {@link Product Products}
+     */
+    Page<P> readProductsByIds(List<String> productIds,
+            @Nullable Pageable page,
+            @Nullable ContextInfo contextInfo);
+}

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/external/AbstractExternalProvider.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/external/AbstractExternalProvider.java
@@ -40,7 +40,10 @@ import com.broadleafcommerce.subscriptionoperation.exception.ProviderApiExceptio
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.security.InvalidParameterException;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -208,5 +211,27 @@ public abstract class AbstractExternalProvider {
         return Optional.ofNullable(apiError.getBody())
                 .map(errorBody -> StringUtils.equals(ENTITY_NOT_FOUND, errorBody.getType()))
                 .orElse(false);
+    }
+
+    /**
+     * Convenience method to generate a map of variables.
+     *
+     * @param keysAndValues the keys and values (in pairs, alternating) to transform into a map
+     * @return the keys and values as a map
+     */
+    protected Map<String, Object> uriVars(Object... keysAndValues) {
+        if (keysAndValues.length % 2 != 0) {
+            throw new InvalidParameterException("Input must be in pairs");
+        }
+
+        Map<String, Object> uriVariables = new HashMap<>();
+
+        for (int i = 0; i < keysAndValues.length; i += 2) {
+            Object key = keysAndValues[i];
+            Object value = keysAndValues[i + 1];
+            uriVariables.put(String.valueOf(key), value);
+        }
+
+        return uriVariables;
     }
 }

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/external/ExternalCatalogProvider.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/external/ExternalCatalogProvider.java
@@ -57,6 +57,25 @@ public class ExternalCatalogProvider<P extends Product> extends AbstractExternal
     }
 
     @Override
+    public P readProductById(String productId,
+            @Nullable ContextInfo contextInfo) {
+        String uri = getBaseUri()
+                .toUriString();
+
+        // TODO: add properties and paths
+        return executeRequest(() -> getWebClient()
+                .get()
+                .uri(uri)
+                .headers(headers -> headers.putAll(getHeaders(contextInfo)))
+                .attributes(clientRegistrationId(getServiceClient()))
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<P>() {})
+                .blockOptional()
+                .orElseThrow(EntityMissingException::new));
+    }
+
+    @Override
     public Page<P> readProductsByIds(@lombok.NonNull List<String> productIds,
             @Nullable Pageable pageable,
             @Nullable ContextInfo contextInfo) {

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/external/ExternalCatalogProvider.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/external/ExternalCatalogProvider.java
@@ -60,9 +60,10 @@ public class ExternalCatalogProvider<P extends Product> extends AbstractExternal
     public P readProductById(String productId,
             @Nullable ContextInfo contextInfo) {
         String uri = getBaseUri()
+                .path(properties.getProductUri())
+                .uriVariables(uriVars("productId", productId))
                 .toUriString();
 
-        // TODO: add properties and paths
         return executeRequest(() -> getWebClient()
                 .get()
                 .uri(uri)
@@ -82,7 +83,7 @@ public class ExternalCatalogProvider<P extends Product> extends AbstractExternal
         Node filters = buildReadProductsByIdsFilters(productIds);
 
         String uri = getBaseUri()
-                .queryParam("cq", filters)
+                .queryParam(RSQL_FILTER_PARAM, filters)
                 .queryParams(pageableToParams(pageable))
                 .toUriString();
 

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/external/ExternalCatalogProvider.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/external/ExternalCatalogProvider.java
@@ -16,7 +16,6 @@
  */
 package com.broadleafcommerce.subscriptionoperation.service.provider.external;
 
-import static com.broadleafcommerce.data.tracking.core.filtering.fetch.rsql.RsqlSearchOperation.IN;
 import static org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction.clientRegistrationId;
 
 import org.springframework.core.ParameterizedTypeReference;
@@ -35,17 +34,15 @@ import com.broadleafcommerce.subscriptionoperation.service.provider.CatalogProvi
 import com.broadleafcommerce.subscriptionoperation.service.provider.page.ResponsePageGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import cz.jirutka.rsql.parser.ast.AndNode;
-import cz.jirutka.rsql.parser.ast.ComparisonNode;
-import cz.jirutka.rsql.parser.ast.Node;
 import lombok.AccessLevel;
 import lombok.Getter;
 
 public class ExternalCatalogProvider<P extends Product> extends AbstractExternalProvider
         implements CatalogProvider<P> {
+
+    protected static final String ID_IN_QUERY_PARAM = "contextId=in=(%s)";
 
     @Getter(AccessLevel.PROTECTED)
     private final ExternalCatalogProviderProperties properties;
@@ -80,7 +77,7 @@ public class ExternalCatalogProvider<P extends Product> extends AbstractExternal
     public Page<P> readProductsByIds(@lombok.NonNull List<String> productIds,
             @Nullable Pageable pageable,
             @Nullable ContextInfo contextInfo) {
-        Node filters = buildReadProductsByIdsFilters(productIds);
+        String filters = buildReadProductsByIdsFilters(productIds);
 
         String uri = getBaseUri()
                 .queryParam(RSQL_FILTER_PARAM, filters)
@@ -101,17 +98,13 @@ public class ExternalCatalogProvider<P extends Product> extends AbstractExternal
     }
 
     /**
-     * Build the {@link Node RSQL filters} used for reading the products by IDs.
+     * Build the RSQL filters in a String form used for reading the products by IDs.
      *
      * @param productIds the list of product ids.
-     * @return the {@link Node RSQL filters} used for reading the products by IDs
+     * @return the RSQL filters in a String form used for reading the products by IDs
      */
-    protected Node buildReadProductsByIdsFilters(@lombok.NonNull List<String> productIds) {
-        List<Node> allFilters = new ArrayList<>();
-        ComparisonNode idsIn =
-                new ComparisonNode(IN.getOperator(), "contextId", productIds);
-        allFilters.add(idsIn);
-        return new AndNode(allFilters);
+    protected String buildReadProductsByIdsFilters(@lombok.NonNull List<String> productIds) {
+        return String.format(ID_IN_QUERY_PARAM, String.join(",", productIds));
     }
 
     /**

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/external/ExternalCatalogProvider.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/external/ExternalCatalogProvider.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2024 Broadleaf Commerce
+ *
+ * Licensed under the Broadleaf End User License Agreement (EULA), Version 1.1 (the
+ * "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt).
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the
+ * "Custom License") between you and Broadleaf Commerce. You may not use this file except in
+ * compliance with the applicable license.
+ *
+ * NOTICE: All information contained herein is, and remains the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained herein are proprietary to Broadleaf Commerce,
+ * LLC and may be covered by U.S. and Foreign Patents, patents in process, and are protected by
+ * trade secret or copyright law. Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
+ */
+package com.broadleafcommerce.subscriptionoperation.service.provider.external;
+
+import static org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction.clientRegistrationId;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.lang.Nullable;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.broadleafcommerce.common.extension.TypeFactory;
+import com.broadleafcommerce.data.tracking.core.context.ContextInfo;
+import com.broadleafcommerce.data.tracking.core.exception.EntityMissingException;
+import com.broadleafcommerce.subscriptionoperation.domain.Product;
+import com.broadleafcommerce.subscriptionoperation.service.provider.CatalogProvider;
+import com.broadleafcommerce.subscriptionoperation.service.provider.page.ResponsePageGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+
+public class ExternalCatalogProvider<P extends Product> extends AbstractExternalProvider
+        implements CatalogProvider<P> {
+
+    @Getter(AccessLevel.PROTECTED)
+    private final ExternalCatalogProviderProperties properties;
+
+    public ExternalCatalogProvider(WebClient webClient, ObjectMapper objectMapper,
+            TypeFactory typeFactory, ExternalCatalogProviderProperties properties) {
+        super(webClient, objectMapper, typeFactory);
+        this.properties = properties;
+    }
+
+    @Override
+    public Page<P> readProductsByIds(@lombok.NonNull List<String> productIds,
+            @Nullable Pageable page,
+            @Nullable ContextInfo contextInfo) {
+        return executeRequest(() -> getWebClient()
+                .get()
+                .uri(getBaseUri().toUriString())
+                .headers(headers -> headers.putAll(getHeaders(contextInfo)))
+                .attributes(clientRegistrationId(getServiceClient()))
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToMono(getPageType())
+                .blockOptional()
+                .map(ResponsePageGenerator::getPage)
+                .orElseThrow(EntityMissingException::new));
+    }
+
+    /**
+     * Gets the type reference for a page generator of item list items.
+     *
+     * @return type reference for a page generator of item list items
+     */
+    protected ParameterizedTypeReference<ResponsePageGenerator<P>> getPageType() {
+        return new ParameterizedTypeReference<>() {};
+    }
+
+    /**
+     * Gets the base URI common to all requests this provider will make.
+     *
+     * @return a URI components builder with the base URI set up
+     */
+    protected UriComponentsBuilder getBaseUri() {
+        return UriComponentsBuilder.fromHttpUrl(properties.getUrl())
+                .path(properties.getProductsUri());
+    }
+
+    protected String getServiceClient() {
+        return properties.getServiceClient();
+    }
+}

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/external/ExternalCatalogProviderProperties.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/external/ExternalCatalogProviderProperties.java
@@ -35,6 +35,11 @@ public class ExternalCatalogProviderProperties {
     private String productsUri = "/products";
 
     /**
+     * The base uri path to the products endpoint
+     */
+    private String productUri = productsUri + "/{productId}";
+
+    /**
      * The service client to use when calling catalog services. Default is "subscriptionopsclient".
      */
     private String serviceClient = "subscriptionopsclient";

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/external/ExternalCatalogProviderProperties.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/service/provider/external/ExternalCatalogProviderProperties.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 Broadleaf Commerce
+ *
+ * Licensed under the Broadleaf End User License Agreement (EULA), Version 1.1 (the
+ * "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt).
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the
+ * "Custom License") between you and Broadleaf Commerce. You may not use this file except in
+ * compliance with the applicable license.
+ *
+ * NOTICE: All information contained herein is, and remains the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained herein are proprietary to Broadleaf Commerce,
+ * LLC and may be covered by U.S. and Foreign Patents, patents in process, and are protected by
+ * trade secret or copyright law. Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
+ */
+package com.broadleafcommerce.subscriptionoperation.service.provider.external;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Data;
+
+@Data
+@ConfigurationProperties("broadleaf.subscriptionoperation.catalogprovider")
+public class ExternalCatalogProviderProperties {
+
+    /**
+     * The base url for an external service holding products.
+     */
+    private String url;
+
+    /**
+     * The base uri path to the products endpoint
+     */
+    private String productsUri = "/products";
+
+    /**
+     * The service client to use when calling catalog services. Default is "subscriptionopsclient".
+     */
+    private String serviceClient = "subscriptionopsclient";
+}

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionActionRequest.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionActionRequest.java
@@ -51,13 +51,13 @@ public class SubscriptionActionRequest implements Serializable {
      * @see DefaultUserRefTypes
      */
     @JsonIgnore
-    private String userType;
+    private String userRefType;
 
     /**
-     * The id of the user making the request.
+     * The reference to the user making the request.
      */
     @JsonIgnore
-    private String userId;
+    private String userRef;
 
     /**
      * Additional request attributes.

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionActionRequest.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionActionRequest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024 Broadleaf Commerce
+ *
+ * Licensed under the Broadleaf End User License Agreement (EULA), Version 1.1 (the
+ * "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt).
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the
+ * "Custom License") between you and Broadleaf Commerce. You may not use this file except in
+ * compliance with the applicable license.
+ *
+ * NOTICE: All information contained herein is, and remains the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained herein are proprietary to Broadleaf Commerce,
+ * LLC and may be covered by U.S. and Foreign Patents, patents in process, and are protected by
+ * trade secret or copyright law. Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
+ */
+package com.broadleafcommerce.subscriptionoperation.web.domain;
+
+import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
+import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.Data;
+
+/**
+ * A request DTO to see what actions are available for a {@link Subscription}.
+ *
+ * @see DefaultSubscriptionActionTypes
+ * @author Sunny Yu
+ */
+@Data
+public class SubscriptionActionRequest implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The id of the subscription to get the available actions for.
+     */
+    private String subscriptionId;
+
+    /**
+     * Additional request attributes.
+     */
+    private Map<String, Object> requestAttributes = new HashMap<>();
+}

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionActionRequest.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionActionRequest.java
@@ -18,6 +18,8 @@ package com.broadleafcommerce.subscriptionoperation.web.domain;
 
 import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
 import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes;
+import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultUserRefTypes;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -42,6 +44,20 @@ public class SubscriptionActionRequest implements Serializable {
      * The id of the subscription to get the available actions for.
      */
     private String subscriptionId;
+
+    /**
+     * The type of the user making the request.
+     *
+     * @see DefaultUserRefTypes
+     */
+    @JsonIgnore
+    private String userType;
+
+    /**
+     * The id of the user making the request.
+     */
+    @JsonIgnore
+    private String userId;
 
     /**
      * Additional request attributes.

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionActionRequest.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionActionRequest.java
@@ -17,7 +17,7 @@
 package com.broadleafcommerce.subscriptionoperation.web.domain;
 
 import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
-import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes;
+import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionType;
 import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultUserRefTypes;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -31,7 +31,7 @@ import lombok.Data;
 /**
  * A request DTO to see what actions are available for a {@link Subscription}.
  *
- * @see DefaultSubscriptionActionTypes
+ * @see DefaultSubscriptionActionType
  * @author Sunny Yu
  */
 @Data

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionActionResponse.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionActionResponse.java
@@ -17,7 +17,7 @@
 package com.broadleafcommerce.subscriptionoperation.web.domain;
 
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionAction;
-import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes;
+import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionType;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -47,7 +47,7 @@ public class SubscriptionActionResponse implements Serializable {
     private List<SubscriptionAction> availableActions = new ArrayList<>();
 
     /**
-     * The unavailable {@link DefaultSubscriptionActionTypes SubscriptionActionTypes} along with
+     * The unavailable {@link DefaultSubscriptionActionType SubscriptionActionTypes} along with
      * unavailable reasons for this subscription.
      */
     private Map<String, List<String>> unavailableReasonsByActionType = new HashMap<>();

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionActionResponse.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionActionResponse.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 Broadleaf Commerce
+ *
+ * Licensed under the Broadleaf End User License Agreement (EULA), Version 1.1 (the
+ * "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt).
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the
+ * "Custom License") between you and Broadleaf Commerce. You may not use this file except in
+ * compliance with the applicable license.
+ *
+ * NOTICE: All information contained herein is, and remains the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained herein are proprietary to Broadleaf Commerce,
+ * LLC and may be covered by U.S. and Foreign Patents, patents in process, and are protected by
+ * trade secret or copyright law. Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
+ */
+package com.broadleafcommerce.subscriptionoperation.web.domain;
+
+import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionAction;
+import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import lombok.Data;
+
+/**
+ * A response DTO containing the available {@link SubscriptionAction SubscriptionActions} and
+ * unavailable {@link SubscriptionAction SubscriptionActions} along with the unavailable reasons.
+ *
+ * @author Sunny Yu
+ */
+@Data
+public class SubscriptionActionResponse implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The available {@link SubscriptionAction SubscriptionActions} that may be possible for this
+     * subscription.
+     */
+    private List<SubscriptionAction> availableActions = new ArrayList<>();
+
+    /**
+     * The unavailable {@link DefaultSubscriptionActionTypes SubscriptionActionTypes} along with
+     * unavailable reasons for this subscription.
+     */
+    private Map<String, List<String>> unavailableReasonsByActionType = new HashMap<>();
+}

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionCancellationRequest.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionCancellationRequest.java
@@ -16,6 +16,8 @@
  */
 package com.broadleafcommerce.subscriptionoperation.web.domain;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,7 +31,10 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class SubscriptionCancellationRequest {
+public class SubscriptionCancellationRequest implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     /**
      * TODO

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionDowngradeRequest.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionDowngradeRequest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 Broadleaf Commerce
+ *
+ * Licensed under the Broadleaf End User License Agreement (EULA), Version 1.1 (the
+ * "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt).
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the
+ * "Custom License") between you and Broadleaf Commerce. You may not use this file except in
+ * compliance with the applicable license.
+ *
+ * NOTICE: All information contained herein is, and remains the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained herein are proprietary to Broadleaf Commerce,
+ * LLC and may be covered by U.S. and Foreign Patents, patents in process, and are protected by
+ * trade secret or copyright law. Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
+ */
+package com.broadleafcommerce.subscriptionoperation.web.domain;
+
+import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SubscriptionDowngradeRequest {
+
+    Subscription newSubscription;
+
+    String priorSubscriptionId;
+}

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionDowngradeRequest.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionDowngradeRequest.java
@@ -21,12 +21,10 @@ import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
 import java.io.Serial;
 import java.io.Serializable;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
 public class SubscriptionDowngradeRequest implements Serializable {
 

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionDowngradeRequest.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionDowngradeRequest.java
@@ -18,6 +18,9 @@ package com.broadleafcommerce.subscriptionoperation.web.domain;
 
 import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -25,9 +28,12 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class SubscriptionDowngradeRequest {
+public class SubscriptionDowngradeRequest implements Serializable {
 
-    Subscription newSubscription;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
-    String priorSubscriptionId;
+    private Subscription newSubscription;
+
+    private String priorSubscriptionId;
 }

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionUpgradeRequest.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionUpgradeRequest.java
@@ -21,12 +21,10 @@ import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
 import java.io.Serial;
 import java.io.Serializable;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
 public class SubscriptionUpgradeRequest implements Serializable {
 

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionUpgradeRequest.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/domain/SubscriptionUpgradeRequest.java
@@ -18,6 +18,9 @@ package com.broadleafcommerce.subscriptionoperation.web.domain;
 
 import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -25,9 +28,12 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class SubscriptionUpgradeRequest {
+public class SubscriptionUpgradeRequest implements Serializable {
 
-    Subscription newSubscription;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
-    String priorSubscriptionId;
+    private Subscription newSubscription;
+
+    private String priorSubscriptionId;
 }

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpoint.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpoint.java
@@ -28,6 +28,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.broadleafcommerce.data.tracking.core.context.ContextInfo;
 import com.broadleafcommerce.data.tracking.core.context.ContextOperation;
@@ -67,12 +68,14 @@ public class AccountSubscriptionOperationEndpoint {
             ownerIdentifierParam = 0, ownerIdentifier = "acct_id,parent_accts")
     public Page<SubscriptionWithItems> readAllAccountSubscriptions(
             @PathVariable("accountId") String accountId,
+            @RequestParam(value = "getActions", required = false,
+                    defaultValue = "false") boolean getActions,
             @PageableDefault(sort = "tracking.basicAudit.creationTime",
                     direction = Sort.Direction.DESC) Pageable page,
             Node filters,
             @ContextOperation(OperationType.READ) final ContextInfo contextInfo) {
         return subscriptionOperationService.readSubscriptionsForUserRefTypeAndUserRef(
-                DefaultUserRefTypes.BLC_ACCOUNT.name(), accountId, page, filters, contextInfo);
+                DefaultUserRefTypes.BLC_ACCOUNT.name(), accountId, getActions, page, filters, contextInfo);
     }
 
     @FrameworkGetMapping(value = "/{subscriptionId}")

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpoint.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpoint.java
@@ -84,7 +84,7 @@ public class AccountSubscriptionOperationEndpoint {
             @PathVariable("accountId") String accountId,
             @PathVariable("subscriptionId") String subscriptionId,
             @RequestParam(value = "getActions", required = false,
-                    defaultValue = "false") boolean getActions,
+                    defaultValue = "true") boolean getActions,
             @ContextOperation(OperationType.READ) final ContextInfo contextInfo) {
         return subscriptionOperationService.readUserSubscriptionById(
                 DefaultUserRefTypes.BLC_ACCOUNT.name(), accountId, subscriptionId, getActions,

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpoint.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpoint.java
@@ -16,25 +16,19 @@
  */
 package com.broadleafcommerce.subscriptionoperation.web.endpoint;
 
-import static com.broadleafcommerce.data.tracking.core.filtering.fetch.rsql.RsqlSearchOperation.EQUAL;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkGetMapping;
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkMapping;
-import org.broadleafcommerce.frameworkmapping.annotation.FrameworkPostMapping;
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkRestController;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.broadleafcommerce.data.tracking.core.context.ContextInfo;
 import com.broadleafcommerce.data.tracking.core.context.ContextOperation;
-import com.broadleafcommerce.data.tracking.core.exception.EntityMissingException;
 import com.broadleafcommerce.data.tracking.core.policy.IdentityType;
 import com.broadleafcommerce.data.tracking.core.policy.Policy;
 import com.broadleafcommerce.data.tracking.core.type.OperationType;
@@ -43,12 +37,7 @@ import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionItem;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionWithItems;
 import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultUserRefTypes;
 import com.broadleafcommerce.subscriptionoperation.service.SubscriptionOperationService;
-import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionActionRequest;
-import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionActionResponse;
 
-import java.util.List;
-
-import cz.jirutka.rsql.parser.ast.ComparisonNode;
 import cz.jirutka.rsql.parser.ast.Node;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -79,7 +68,8 @@ public class AccountSubscriptionOperationEndpoint {
             Node filters,
             @ContextOperation(OperationType.READ) final ContextInfo contextInfo) {
         return subscriptionOperationService.readSubscriptionsForUserRefTypeAndUserRef(
-                DefaultUserRefTypes.BLC_ACCOUNT.name(), accountId, getActions, page, filters, contextInfo);
+                DefaultUserRefTypes.BLC_ACCOUNT.name(), accountId, getActions, page, filters,
+                contextInfo);
     }
 
     @FrameworkGetMapping(value = "/{subscriptionId}")
@@ -93,6 +83,7 @@ public class AccountSubscriptionOperationEndpoint {
                     defaultValue = "false") boolean getActions,
             @ContextOperation(OperationType.READ) final ContextInfo contextInfo) {
         return subscriptionOperationService.readUserSubscriptionById(
-                DefaultUserRefTypes.BLC_ACCOUNT.name(), accountId, subscriptionId, contextInfo);
+                DefaultUserRefTypes.BLC_ACCOUNT.name(), accountId, subscriptionId, getActions,
+                contextInfo);
     }
 }

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpoint.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpoint.java
@@ -85,6 +85,8 @@ public class AccountSubscriptionOperationEndpoint {
     public SubscriptionWithItems readAccountSubscription(
             @PathVariable("accountId") String accountId,
             @PathVariable("subscriptionId") String subscriptionId,
+            @RequestParam(value = "getActions", required = false,
+                    defaultValue = "false") boolean getActions,
             @ContextOperation(OperationType.READ) final ContextInfo contextInfo) {
         return subscriptionOperationService.readUserSubscriptionById(
                 DefaultUserRefTypes.BLC_ACCOUNT.name(), accountId, subscriptionId, contextInfo);

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpoint.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpoint.java
@@ -19,12 +19,14 @@ package com.broadleafcommerce.subscriptionoperation.web.endpoint;
 
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkGetMapping;
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkMapping;
+import org.broadleafcommerce.frameworkmapping.annotation.FrameworkPostMapping;
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkRestController;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.broadleafcommerce.data.tracking.core.context.ContextInfo;
@@ -37,6 +39,8 @@ import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionItem;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionWithItems;
 import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultUserRefTypes;
 import com.broadleafcommerce.subscriptionoperation.service.SubscriptionOperationService;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionActionRequest;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionActionResponse;
 
 import cz.jirutka.rsql.parser.ast.Node;
 import lombok.AccessLevel;
@@ -85,5 +89,21 @@ public class AccountSubscriptionOperationEndpoint {
         return subscriptionOperationService.readUserSubscriptionById(
                 DefaultUserRefTypes.BLC_ACCOUNT.name(), accountId, subscriptionId, getActions,
                 contextInfo);
+    }
+
+    @FrameworkPostMapping(value = "/{subscriptionId}/actions")
+    @Policy(permissionRoots = "ACCOUNT_SUBSCRIPTION",
+            identityTypes = {IdentityType.ADMIN, IdentityType.OWNER},
+            ownerIdentifierParam = 0, ownerIdentifier = "acct_id,parent_accts")
+    public SubscriptionActionResponse readAccountSubscriptionActions(
+            @PathVariable("accountId") String accountId,
+            @PathVariable("subscriptionId") String subscriptionId,
+            @RequestBody SubscriptionActionRequest request,
+            @ContextOperation(OperationType.READ) final ContextInfo contextInfo) {
+        request.setSubscriptionId(subscriptionId);
+        request.setUserRefType(DefaultUserRefTypes.BLC_ACCOUNT.name());
+        request.setUserRef(accountId);
+
+        return subscriptionOperationService.readSubscriptionActions(request, contextInfo);
     }
 }

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpoint.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpoint.java
@@ -21,6 +21,7 @@ import static com.broadleafcommerce.data.tracking.core.filtering.fetch.rsql.Rsql
 import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkGetMapping;
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkMapping;
+import org.broadleafcommerce.frameworkmapping.annotation.FrameworkPostMapping;
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkRestController;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,6 +29,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.broadleafcommerce.data.tracking.core.context.ContextInfo;
@@ -41,6 +43,8 @@ import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionItem;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionWithItems;
 import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultUserRefTypes;
 import com.broadleafcommerce.subscriptionoperation.service.SubscriptionOperationService;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionActionRequest;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionActionResponse;
 
 import java.util.List;
 

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpoint.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpoint.java
@@ -16,6 +16,9 @@
  */
 package com.broadleafcommerce.subscriptionoperation.web.endpoint;
 
+import static com.broadleafcommerce.data.tracking.core.filtering.fetch.rsql.RsqlSearchOperation.EQUAL;
+
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkGetMapping;
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkMapping;
 import org.broadleafcommerce.frameworkmapping.annotation.FrameworkRestController;
@@ -23,10 +26,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.PathVariable;
 
 import com.broadleafcommerce.data.tracking.core.context.ContextInfo;
 import com.broadleafcommerce.data.tracking.core.context.ContextOperation;
+import com.broadleafcommerce.data.tracking.core.exception.EntityMissingException;
 import com.broadleafcommerce.data.tracking.core.policy.IdentityType;
 import com.broadleafcommerce.data.tracking.core.policy.Policy;
 import com.broadleafcommerce.data.tracking.core.type.OperationType;
@@ -36,11 +41,16 @@ import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionWithItems;
 import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultUserRefTypes;
 import com.broadleafcommerce.subscriptionoperation.service.SubscriptionOperationService;
 
+import java.util.List;
+
+import cz.jirutka.rsql.parser.ast.ComparisonNode;
 import cz.jirutka.rsql.parser.ast.Node;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 @FrameworkRestController
 @FrameworkMapping(AccountSubscriptionOperationEndpoint.BASE_URI)

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpoint.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpoint.java
@@ -39,6 +39,8 @@ import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionItem;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionWithItems;
 import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultUserRefTypes;
 import com.broadleafcommerce.subscriptionoperation.service.SubscriptionOperationService;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionActionRequest;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionActionResponse;
 import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionCancellationRequest;
 import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionUpgradeRequest;
 
@@ -85,6 +87,22 @@ public class CustomerSubscriptionOperationEndpoint {
             @ContextOperation(OperationType.READ) final ContextInfo contextInfo) {
         return subscriptionOperationService.readUserSubscriptionById(
                 DefaultUserRefTypes.BLC_CUSTOMER.name(), customerId, subscriptionId, contextInfo);
+    }
+
+    @FrameworkPostMapping(value = "/{subscriptionId}/actions")
+    @Policy(permissionRoots = "CUSTOMER_SUBSCRIPTION",
+            identityTypes = {IdentityType.OWNER},
+            ownerIdentifierParam = 0)
+    public SubscriptionActionResponse readCustomerSubscriptionActions(
+            @PathVariable("customerId") String customerId,
+            @PathVariable("subscriptionId") String subscriptionId,
+            @RequestBody SubscriptionActionRequest request,
+            @ContextOperation(OperationType.READ) final ContextInfo contextInfo) {
+        request.setSubscriptionId(subscriptionId);
+        request.setUserType(DefaultUserRefTypes.BLC_CUSTOMER.name());
+        request.setUserId(customerId);
+
+        return subscriptionOperationService.readSubscriptionActions(request, contextInfo);
     }
 
     @FrameworkPostMapping(value = "/{subscriptionId}/upgrade",

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpoint.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpoint.java
@@ -80,6 +80,8 @@ public class CustomerSubscriptionOperationEndpoint {
     public SubscriptionWithItems readCustomerSubscription(
             @PathVariable("customerId") String customerId,
             @PathVariable("subscriptionId") String subscriptionId,
+            @RequestParam(value = "getActions", required = false,
+                    defaultValue = "false") boolean getActions,
             @ContextOperation(OperationType.READ) final ContextInfo contextInfo) {
         return subscriptionOperationService.readUserSubscriptionById(
                 DefaultUserRefTypes.BLC_CUSTOMER.name(), customerId, subscriptionId, contextInfo);

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpoint.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpoint.java
@@ -84,7 +84,7 @@ public class CustomerSubscriptionOperationEndpoint {
             @PathVariable("customerId") String customerId,
             @PathVariable("subscriptionId") String subscriptionId,
             @RequestParam(value = "getActions", required = false,
-                    defaultValue = "false") boolean getActions,
+                    defaultValue = "true") boolean getActions,
             @ContextOperation(OperationType.READ) final ContextInfo contextInfo) {
         return subscriptionOperationService.readUserSubscriptionById(
                 DefaultUserRefTypes.BLC_CUSTOMER.name(), customerId, subscriptionId, getActions,

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpoint.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpoint.java
@@ -72,7 +72,8 @@ public class CustomerSubscriptionOperationEndpoint {
             Node filters,
             @ContextOperation(OperationType.READ) final ContextInfo contextInfo) {
         return subscriptionOperationService.readSubscriptionsForUserRefTypeAndUserRef(
-                DefaultUserRefTypes.BLC_CUSTOMER.name(), customerId, getActions, page, filters, contextInfo);
+                DefaultUserRefTypes.BLC_CUSTOMER.name(), customerId, getActions, page, filters,
+                contextInfo);
     }
 
     @FrameworkGetMapping(value = "/{subscriptionId}")
@@ -86,7 +87,8 @@ public class CustomerSubscriptionOperationEndpoint {
                     defaultValue = "false") boolean getActions,
             @ContextOperation(OperationType.READ) final ContextInfo contextInfo) {
         return subscriptionOperationService.readUserSubscriptionById(
-                DefaultUserRefTypes.BLC_CUSTOMER.name(), customerId, subscriptionId, contextInfo);
+                DefaultUserRefTypes.BLC_CUSTOMER.name(), customerId, subscriptionId, getActions,
+                contextInfo);
     }
 
     @FrameworkPostMapping(value = "/{subscriptionId}/actions")

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpoint.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpoint.java
@@ -27,6 +27,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.broadleafcommerce.data.tracking.core.context.ContextInfo;
 import com.broadleafcommerce.data.tracking.core.context.ContextOperation;
@@ -62,12 +63,14 @@ public class CustomerSubscriptionOperationEndpoint {
             ownerIdentifierParam = 0)
     public Page<SubscriptionWithItems> readAllCustomerSubscriptions(
             @PathVariable("customerId") String customerId,
+            @RequestParam(value = "getActions", required = false,
+                    defaultValue = "false") boolean getActions,
             @PageableDefault(sort = "tracking.basicAudit.creationTime",
                     direction = Sort.Direction.DESC) Pageable page,
             Node filters,
             @ContextOperation(OperationType.READ) final ContextInfo contextInfo) {
         return subscriptionOperationService.readSubscriptionsForUserRefTypeAndUserRef(
-                DefaultUserRefTypes.BLC_CUSTOMER.name(), customerId, page, filters, contextInfo);
+                DefaultUserRefTypes.BLC_CUSTOMER.name(), customerId, getActions, page, filters, contextInfo);
     }
 
     @FrameworkGetMapping(value = "/{subscriptionId}")

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpoint.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpoint.java
@@ -101,8 +101,8 @@ public class CustomerSubscriptionOperationEndpoint {
             @RequestBody SubscriptionActionRequest request,
             @ContextOperation(OperationType.READ) final ContextInfo contextInfo) {
         request.setSubscriptionId(subscriptionId);
-        request.setUserType(DefaultUserRefTypes.BLC_CUSTOMER.name());
-        request.setUserId(customerId);
+        request.setUserRefType(DefaultUserRefTypes.BLC_CUSTOMER.name());
+        request.setUserRef(customerId);
 
         return subscriptionOperationService.readSubscriptionActions(request, contextInfo);
     }

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/SubscriptionOperationEndpoint.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/SubscriptionOperationEndpoint.java
@@ -61,12 +61,14 @@ public class SubscriptionOperationEndpoint {
     public Page<SubscriptionWithItems> readAllUserOwnedSubscriptions(
             @RequestParam("userRefType") String userRefType,
             @RequestParam("userRef") String userRef,
+            @RequestParam(value = "getActions", required = false,
+                    defaultValue = "false") boolean getActions,
             @PageableDefault(sort = "tracking.basicAudit.creationTime",
                     direction = Sort.Direction.DESC) Pageable page,
             Node filters,
             @ContextOperation(OperationType.READ) final ContextInfo contextInfo) {
         return subscriptionOperationService.readSubscriptionsForUserRefTypeAndUserRef(userRefType,
-                userRef, page, filters, contextInfo);
+                userRef, getActions, page, filters, contextInfo);
     }
 
     @FrameworkGetMapping(value = "/{subscriptionId}")

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/exception/SubscriptionOperationExceptionAdvisor.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/exception/SubscriptionOperationExceptionAdvisor.java
@@ -29,6 +29,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import com.broadleafcommerce.common.error.ApiError;
 import com.broadleafcommerce.common.error.validation.web.FrameworkExceptionAdvisor;
 import com.broadleafcommerce.subscriptionoperation.exception.ProviderApiException;
+import com.broadleafcommerce.subscriptionoperation.service.exception.InsufficientSubscriptionAccessException;
 import com.broadleafcommerce.subscriptionoperation.service.exception.InvalidSubscriptionCreationRequestException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -60,6 +61,17 @@ public class SubscriptionOperationExceptionAdvisor {
         return new ApiError("INVALID_SUBSCRIPTION_CREATION_REQUEST",
                 ex.getMessage(),
                 HttpStatus.BAD_REQUEST)
+                        .toResponseEntity();
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiError> handleInvalidSubscriptionAccessException(
+            InsufficientSubscriptionAccessException ex,
+            WebRequest request) {
+        logDebug(ex, request);
+        return new ApiError("INSUFFICIENT_SUBSCRIPTION_ACCESS",
+                ex.getMessage(),
+                HttpStatus.FORBIDDEN)
                         .toResponseEntity();
     }
 

--- a/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/exception/SubscriptionOperationExceptionAdvisor.java
+++ b/services/src/main/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/exception/SubscriptionOperationExceptionAdvisor.java
@@ -31,6 +31,8 @@ import com.broadleafcommerce.common.error.validation.web.FrameworkExceptionAdvis
 import com.broadleafcommerce.subscriptionoperation.exception.ProviderApiException;
 import com.broadleafcommerce.subscriptionoperation.service.exception.InsufficientSubscriptionAccessException;
 import com.broadleafcommerce.subscriptionoperation.service.exception.InvalidSubscriptionCreationRequestException;
+import com.broadleafcommerce.subscriptionoperation.service.exception.InvalidSubscriptionDowngradeRequestException;
+import com.broadleafcommerce.subscriptionoperation.service.exception.InvalidSubscriptionUpgradeRequestException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -59,6 +61,28 @@ public class SubscriptionOperationExceptionAdvisor {
             WebRequest request) {
         logDebug(ex, request);
         return new ApiError("INVALID_SUBSCRIPTION_CREATION_REQUEST",
+                ex.getMessage(),
+                HttpStatus.BAD_REQUEST)
+                        .toResponseEntity();
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiError> handleInvalidSubscriptionUpgradeRequestException(
+            InvalidSubscriptionUpgradeRequestException ex,
+            WebRequest request) {
+        logDebug(ex, request);
+        return new ApiError("INVALID_SUBSCRIPTION_UPGRADE_REQUEST",
+                ex.getMessage(),
+                HttpStatus.BAD_REQUEST)
+                        .toResponseEntity();
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiError> handleInvalidSubscriptionDowngradeRequestException(
+            InvalidSubscriptionDowngradeRequestException ex,
+            WebRequest request) {
+        logDebug(ex, request);
+        return new ApiError("INVALID_SUBSCRIPTION_DOWNGRADE_REQUEST",
                 ex.getMessage(),
                 HttpStatus.BAD_REQUEST)
                         .toResponseEntity();

--- a/services/src/main/resources/subscriptionoperation-defaults.yml
+++ b/services/src/main/resources/subscriptionoperation-defaults.yml
@@ -32,3 +32,6 @@ broadleaf:
       url: https://localhost:8467/billing
       subscriptions-path: /subscriptions
       subscription-with-items-path: /{subscriptionId}/items
+    catalogprovider:
+      url: https://localhost:8442/catalog
+      products-uri: /products

--- a/services/src/main/resources/subscriptionoperation-defaults.yml
+++ b/services/src/main/resources/subscriptionoperation-defaults.yml
@@ -35,3 +35,4 @@ broadleaf:
     catalogprovider:
       url: https://localhost:8442/catalog
       products-uri: /products
+      product-uri: /{productId}

--- a/services/src/test/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionValidationServiceTest.java
+++ b/services/src/test/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionValidationServiceTest.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright (C) 2024 Broadleaf Commerce
+ *
+ * Licensed under the Broadleaf End User License Agreement (EULA), Version 1.1 (the
+ * "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt).
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the
+ * "Custom License") between you and Broadleaf Commerce. You may not use this file except in
+ * compliance with the applicable license.
+ *
+ * NOTICE: All information contained herein is, and remains the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained herein are proprietary to Broadleaf Commerce,
+ * LLC and may be covered by U.S. and Foreign Patents, patents in process, and are protected by
+ * trade secret or copyright law. Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained from Broadleaf Commerce, LLC.
+ */
+package com.broadleafcommerce.subscriptionoperation.service;
+
+import static com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes.CANCEL;
+import static com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes.DOWNGRADE;
+import static com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes.UPGRADE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.broadleafcommerce.data.tracking.core.policy.PolicyResponse;
+import com.broadleafcommerce.data.tracking.core.policy.trackable.TrackablePolicyUtils;
+import com.broadleafcommerce.subscriptionoperation.domain.Product;
+import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultUserRefTypes;
+import com.broadleafcommerce.subscriptionoperation.service.exception.InsufficientSubscriptionAccessException;
+import com.broadleafcommerce.subscriptionoperation.service.exception.InvalidSubscriptionCreationRequestException;
+import com.broadleafcommerce.subscriptionoperation.service.exception.InvalidSubscriptionDowngradeRequestException;
+import com.broadleafcommerce.subscriptionoperation.service.exception.InvalidSubscriptionUpgradeRequestException;
+import com.broadleafcommerce.subscriptionoperation.service.provider.CatalogProvider;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionCancellationRequest;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionCreationRequest;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionDowngradeRequest;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionItemCreationRequest;
+import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionUpgradeRequest;
+
+import java.util.Collections;
+
+@ExtendWith(MockitoExtension.class)
+public class DefaultSubscriptionValidationServiceTest {
+
+    private static final String CUSTOMER_ID = "customerId";
+
+    @Mock
+    private CatalogProvider<Product> catalogProvider;
+    @Mock
+    private TrackablePolicyUtils policyUtils;
+
+    private DefaultSubscriptionValidationService subValidationService;
+
+    @BeforeEach
+    void setup() {
+        subValidationService = spy(new DefaultSubscriptionValidationService(catalogProvider));
+        subValidationService.setPolicyUtils(policyUtils);
+    }
+
+    @Test
+    public void testValidSubCreation() {
+        SubscriptionCreationRequest request = buildValidCreationRequest();
+        assertDoesNotThrow(() -> subValidationService.validateSubscriptionCreation(request, null));
+    }
+
+    @Test
+    public void testInvalidSubCreation_missingUserRef() {
+        SubscriptionCreationRequest request = buildValidCreationRequest();
+        request.setUserRefType(null);
+
+        assertThatThrownBy(() -> subValidationService.validateSubscriptionCreation(request, null))
+                .isInstanceOf(InvalidSubscriptionCreationRequestException.class)
+                .hasMessage(
+                        "A subscription must be given an owning user/account via userRefType and userRef.");
+
+        request.setUserRefType("refType");
+        request.setUserRef(null);
+        assertThatThrownBy(() -> subValidationService.validateSubscriptionCreation(request, null))
+                .isInstanceOf(InvalidSubscriptionCreationRequestException.class)
+                .hasMessage(
+                        "A subscription must be given an owning user/account via userRefType and userRef.");
+    }
+
+    @Test
+    public void testInvalidSubCreation_missingPeriodType() {
+        SubscriptionCreationRequest request = buildValidCreationRequest();
+        request.setPeriodType(null);
+        assertThatThrownBy(() -> subValidationService.validateSubscriptionCreation(request, null))
+                .isInstanceOf(InvalidSubscriptionCreationRequestException.class)
+                .hasMessage("A subscription must be given a periodType or billingFrequency.");
+    }
+
+    @Test
+    public void testInvalidSubCreation_missingSource() {
+        SubscriptionCreationRequest request = buildValidCreationRequest();
+        request.setSubscriptionSource(null);
+
+        assertThatThrownBy(() -> subValidationService.validateSubscriptionCreation(request, null))
+                .isInstanceOf(InvalidSubscriptionCreationRequestException.class)
+                .hasMessage("A subscription must be given a source or sourceRef.");
+
+        request.setSubscriptionSource("source");
+        request.setSubscriptionSourceRef(null);
+
+        assertThatThrownBy(() -> subValidationService.validateSubscriptionCreation(request, null))
+                .isInstanceOf(InvalidSubscriptionCreationRequestException.class)
+                .hasMessage("A subscription must be given a source or sourceRef.");
+    }
+
+    @Test
+    public void testInvalidSubCreation_missingItemCreationRequests() {
+        SubscriptionCreationRequest request = buildValidCreationRequest();
+        request.setItemCreationRequests(Collections.emptyList());
+
+        assertThatThrownBy(() -> subValidationService.validateSubscriptionCreation(request, null))
+                .isInstanceOf(InvalidSubscriptionCreationRequestException.class)
+                .hasMessage("Subscription items must also be defined for the subscription.");
+    }
+
+    @Test
+    public void testValidateSubscriptionCancellation() {
+        String subId = "subscriptionId";
+        SubscriptionCancellationRequest request = new SubscriptionCancellationRequest();
+        request.setSubscriptionId(subId);
+
+        when(policyUtils.validatePermissions(any(), any()))
+                .thenReturn(PolicyResponse.VALID);
+
+        assertDoesNotThrow(
+                () -> subValidationService.validateSubscriptionCancellation(request, null));
+
+        assertCommonValidationCalled(subId, CANCEL.name());
+    }
+
+    @Test
+    public void testValidateSubscriptionCancellation_invalidAccess() {
+        String subId = "subscriptionId";
+        SubscriptionCancellationRequest request = new SubscriptionCancellationRequest();
+        request.setSubscriptionId(subId);
+
+        when(policyUtils.validatePermissions(any(), any()))
+                .thenReturn(PolicyResponse.NOT_PERMITTED);
+
+        assertThatThrownBy(
+                () -> subValidationService.validateSubscriptionCancellation(request, null))
+                        .isInstanceOf(InsufficientSubscriptionAccessException.class);
+    }
+
+    @Test
+    public void testValidateSubscriptionUpgrade() {
+        String subId = "subscriptionId";
+        SubscriptionUpgradeRequest request = new SubscriptionUpgradeRequest();
+        request.setPriorSubscriptionId(subId);
+
+        Product subscriptionProduct = new Product();
+        subscriptionProduct.setUpgradeProductId("someUpgradeProductId");
+
+        when(policyUtils.validatePermissions(any(), any()))
+                .thenReturn(PolicyResponse.VALID);
+        when(catalogProvider.readProductById(anyString(), any()))
+                .thenReturn(subscriptionProduct);
+
+        assertDoesNotThrow(() -> subValidationService.validateSubscriptionUpgrade(request, null));
+
+        assertCommonValidationCalled(subId, UPGRADE.name());
+    }
+
+    @Test
+    public void testValidateSubscriptionUpgrade_invalidAccess() {
+        String subId = "subscriptionId";
+        SubscriptionUpgradeRequest request = new SubscriptionUpgradeRequest();
+        request.setPriorSubscriptionId(subId);
+
+        Product subscriptionProduct = new Product();
+        subscriptionProduct.setUpgradeProductId("someUpgradeProductId");
+
+        when(policyUtils.validatePermissions(any(), any()))
+                .thenReturn(PolicyResponse.NOT_PERMITTED);
+
+        assertThatThrownBy(() -> subValidationService.validateSubscriptionUpgrade(request, null))
+                .isInstanceOf(InsufficientSubscriptionAccessException.class);
+    }
+
+    // TODO: Update tests once upgrade flow is implemented
+    @Test
+    public void testValidateSubscriptionUpgrade_ineligibleProduct() {
+        String subId = "subscriptionId";
+        SubscriptionUpgradeRequest request = new SubscriptionUpgradeRequest();
+        request.setPriorSubscriptionId(subId);
+
+        Product subscriptionProduct = new Product();
+        subscriptionProduct.setUpgradeProductId(null);
+
+        when(policyUtils.validatePermissions(any(), any()))
+                .thenReturn(PolicyResponse.VALID);
+        when(catalogProvider.readProductById(anyString(), any()))
+                .thenReturn(subscriptionProduct);
+
+        assertThatThrownBy(() -> subValidationService.validateSubscriptionUpgrade(request, null))
+                .isInstanceOf(InvalidSubscriptionUpgradeRequestException.class);
+    }
+
+    @Test
+    public void testValidateSubscriptionDowngrade() {
+        String subId = "subscriptionId";
+        SubscriptionDowngradeRequest request = new SubscriptionDowngradeRequest();
+        request.setPriorSubscriptionId(subId);
+
+        Product subscriptionProduct = new Product();
+        subscriptionProduct.setDowngradeProductId("someDowngradeProductId");
+
+        when(policyUtils.validatePermissions(any(), any()))
+                .thenReturn(PolicyResponse.VALID);
+        when(catalogProvider.readProductById(anyString(), any()))
+                .thenReturn(subscriptionProduct);
+
+        assertDoesNotThrow(() -> subValidationService.validateSubscriptionDowngrade(request, null));
+
+        assertCommonValidationCalled(subId, DOWNGRADE.name());
+    }
+
+    @Test
+    public void testValidateSubscriptionDowngrade_invalidAccess() {
+        String subId = "subscriptionId";
+        SubscriptionDowngradeRequest request = new SubscriptionDowngradeRequest();
+        request.setPriorSubscriptionId(subId);
+
+        Product subscriptionProduct = new Product();
+        subscriptionProduct.setDowngradeProductId("someDowngradeProductId");
+
+        when(policyUtils.validatePermissions(any(), any()))
+                .thenReturn(PolicyResponse.NOT_PERMITTED);
+
+        assertThatThrownBy(() -> subValidationService.validateSubscriptionDowngrade(request, null))
+                .isInstanceOf(InsufficientSubscriptionAccessException.class);
+    }
+
+    // TODO: Update tests once upgrade flow is implemented
+    @Test
+    public void testValidateSubscriptionDowngrade_ineligibleProduct() {
+        String subId = "subscriptionId";
+        SubscriptionDowngradeRequest request = new SubscriptionDowngradeRequest();
+        request.setPriorSubscriptionId(subId);
+
+        Product subscriptionProduct = new Product();
+        subscriptionProduct.setDowngradeProductId(null);
+
+        when(policyUtils.validatePermissions(any(), any()))
+                .thenReturn(PolicyResponse.VALID);
+        when(catalogProvider.readProductById(anyString(), any()))
+                .thenReturn(subscriptionProduct);
+
+        assertThatThrownBy(() -> subValidationService.validateSubscriptionDowngrade(request, null))
+                .isInstanceOf(InvalidSubscriptionDowngradeRequestException.class);
+    }
+
+    private void assertCommonValidationCalled(String subscriptionId, String actionType) {
+        verify(subValidationService, times(1)).getRequiredPermissions(eq(actionType));
+        verify(policyUtils, times(1)).validatePermissions(any(), any());
+        verify(subValidationService, times(1)).validateAdditionalPermissionRules(eq(subscriptionId),
+                eq(actionType), any());
+        verify(subValidationService, times(1)).validateBusinessRules(eq(subscriptionId),
+                eq(actionType), any());
+    }
+
+    private SubscriptionCreationRequest buildValidCreationRequest() {
+        SubscriptionCreationRequest request = new SubscriptionCreationRequest();
+        request.setUserRefType(DefaultUserRefTypes.BLC_CUSTOMER.name());
+        request.setUserRef(CUSTOMER_ID);
+        request.setPeriodType("MONTHLY");
+        request.setSubscriptionSource("SOME_SOURCE");
+        request.setSubscriptionSourceRef("someSourceId");
+
+        SubscriptionItemCreationRequest itemRequest = new SubscriptionItemCreationRequest();
+        itemRequest.setItemName("name");
+        itemRequest.setItemRef("ref");
+        itemRequest.setItemRefType("refType");
+        itemRequest.setQuantity(1);
+
+        request.setItemCreationRequests(Collections.singletonList(itemRequest));
+
+        return request;
+    }
+}

--- a/services/src/test/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionValidationServiceTest.java
+++ b/services/src/test/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionValidationServiceTest.java
@@ -16,9 +16,9 @@
  */
 package com.broadleafcommerce.subscriptionoperation.service;
 
-import static com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes.CANCEL;
-import static com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes.DOWNGRADE;
-import static com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes.UPGRADE;
+import static com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionType.CANCEL;
+import static com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionType.DOWNGRADE;
+import static com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionType.UPGRADE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;

--- a/services/src/test/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionValidationServiceTest.java
+++ b/services/src/test/java/com/broadleafcommerce/subscriptionoperation/service/DefaultSubscriptionValidationServiceTest.java
@@ -107,12 +107,6 @@ public class DefaultSubscriptionValidationServiceTest {
     public void testInvalidSubCreation_missingSource() {
         SubscriptionCreationRequest request = buildValidCreationRequest();
         request.setSubscriptionSource(null);
-
-        assertThatThrownBy(() -> subValidationService.validateSubscriptionCreation(request, null))
-                .isInstanceOf(InvalidSubscriptionCreationRequestException.class)
-                .hasMessage("A subscription must be given a source or sourceRef.");
-
-        request.setSubscriptionSource("source");
         request.setSubscriptionSourceRef(null);
 
         assertThatThrownBy(() -> subValidationService.validateSubscriptionCreation(request, null))

--- a/services/src/test/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpointIT.java
+++ b/services/src/test/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/AccountSubscriptionOperationEndpointIT.java
@@ -45,7 +45,7 @@ import com.broadleafcommerce.data.tracking.core.type.OperationType;
 import com.broadleafcommerce.oauth2.resource.security.test.MockMvcOAuth2AuthenticationUtil;
 import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionWithItems;
-import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes;
+import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionType;
 import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultUserRefTypes;
 import com.broadleafcommerce.subscriptionoperation.service.provider.SubscriptionProvider;
 import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionActionRequest;
@@ -440,15 +440,15 @@ class AccountSubscriptionOperationEndpointIT {
                 .andExpect(status().isOk())
                 // TODO: Update tests once action logic is implemented
                 .andExpect(jsonPath("$.availableActions[*].actionType",
-                        contains(DefaultSubscriptionActionTypes.EDIT.name(),
-                                DefaultSubscriptionActionTypes.CHANGE_AUTO_RENEWAL.name(),
-                                DefaultSubscriptionActionTypes.UPGRADE.name(),
-                                DefaultSubscriptionActionTypes.PAUSE.name(),
-                                DefaultSubscriptionActionTypes.RESUME.name(),
-                                DefaultSubscriptionActionTypes.SUSPEND.name(),
-                                DefaultSubscriptionActionTypes.TERMINATE.name(),
-                                DefaultSubscriptionActionTypes.REACTIVATE.name(),
-                                DefaultSubscriptionActionTypes.CANCEL.name())))
+                        contains(DefaultSubscriptionActionType.EDIT.name(),
+                                DefaultSubscriptionActionType.CHANGE_AUTO_RENEWAL.name(),
+                                DefaultSubscriptionActionType.UPGRADE.name(),
+                                DefaultSubscriptionActionType.PAUSE.name(),
+                                DefaultSubscriptionActionType.RESUME.name(),
+                                DefaultSubscriptionActionType.SUSPEND.name(),
+                                DefaultSubscriptionActionType.TERMINATE.name(),
+                                DefaultSubscriptionActionType.REACTIVATE.name(),
+                                DefaultSubscriptionActionType.CANCEL.name())))
                 .andExpect(jsonPath("$.unavailableReasonsByActionType.DOWNGRADE[0]")
                         .value("Downgrade is not supported"));
     }

--- a/services/src/test/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpointIT.java
+++ b/services/src/test/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/CustomerSubscriptionOperationEndpointIT.java
@@ -45,7 +45,7 @@ import com.broadleafcommerce.data.tracking.core.type.OperationType;
 import com.broadleafcommerce.oauth2.resource.security.test.MockMvcOAuth2AuthenticationUtil;
 import com.broadleafcommerce.subscriptionoperation.domain.Subscription;
 import com.broadleafcommerce.subscriptionoperation.domain.SubscriptionWithItems;
-import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionTypes;
+import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultSubscriptionActionType;
 import com.broadleafcommerce.subscriptionoperation.domain.enums.DefaultUserRefTypes;
 import com.broadleafcommerce.subscriptionoperation.service.provider.SubscriptionProvider;
 import com.broadleafcommerce.subscriptionoperation.web.domain.SubscriptionActionRequest;
@@ -452,15 +452,15 @@ class CustomerSubscriptionOperationEndpointIT {
                 .andExpect(status().isOk())
                 // TODO: Update tests once action logic is implemented
                 .andExpect(jsonPath("$.availableActions[*].actionType",
-                        contains(DefaultSubscriptionActionTypes.EDIT.name(),
-                                DefaultSubscriptionActionTypes.CHANGE_AUTO_RENEWAL.name(),
-                                DefaultSubscriptionActionTypes.UPGRADE.name(),
-                                DefaultSubscriptionActionTypes.PAUSE.name(),
-                                DefaultSubscriptionActionTypes.RESUME.name(),
-                                DefaultSubscriptionActionTypes.SUSPEND.name(),
-                                DefaultSubscriptionActionTypes.TERMINATE.name(),
-                                DefaultSubscriptionActionTypes.REACTIVATE.name(),
-                                DefaultSubscriptionActionTypes.CANCEL.name())))
+                        contains(DefaultSubscriptionActionType.EDIT.name(),
+                                DefaultSubscriptionActionType.CHANGE_AUTO_RENEWAL.name(),
+                                DefaultSubscriptionActionType.UPGRADE.name(),
+                                DefaultSubscriptionActionType.PAUSE.name(),
+                                DefaultSubscriptionActionType.RESUME.name(),
+                                DefaultSubscriptionActionType.SUSPEND.name(),
+                                DefaultSubscriptionActionType.TERMINATE.name(),
+                                DefaultSubscriptionActionType.REACTIVATE.name(),
+                                DefaultSubscriptionActionType.CANCEL.name())))
                 .andExpect(jsonPath("$.unavailableReasonsByActionType.DOWNGRADE[0]")
                         .value("Downgrade is not supported"));
     }

--- a/services/src/test/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/util/InMemorySubscriptionProvider.java
+++ b/services/src/test/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/util/InMemorySubscriptionProvider.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
 
+import cz.jirutka.rsql.parser.ast.ComparisonNode;
 import cz.jirutka.rsql.parser.ast.Node;
 import io.azam.ulidj.ULID;
 import lombok.Getter;

--- a/services/src/test/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/util/InMemorySubscriptionProvider.java
+++ b/services/src/test/java/com/broadleafcommerce/subscriptionoperation/web/endpoint/util/InMemorySubscriptionProvider.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
 
-import cz.jirutka.rsql.parser.ast.ComparisonNode;
 import cz.jirutka.rsql.parser.ast.Node;
 import io.azam.ulidj.ULID;
 import lombok.Getter;


### PR DESCRIPTION
Part of https://app.zenhub.com/workspaces/vfe-b2b-marketplace-66f567a4f1370c001757828b/issues/zh/9

## Main Changes
- Domain & endpoint support to retrieve actions
- Move validation logic to its own service
- Add CatalogProvider to support retrieving a product used for validation
- Add tests